### PR TITLE
Remove datasets and Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-#*.jar filter=lfs diff=lfs merge=lfs -text
-#*.pdf filter=lfs diff=lfs merge=lfs -text
-#*.csv filter=lfs diff=lfs merge=lfs -text
-datasets/** filter=lfs diff=lfs merge=lfs -text

--- a/datasets/DR5/DR5_nowarnings_less05_test.arff
+++ b/datasets/DR5/DR5_nowarnings_less05_test.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:51f20424b7b53a271596aee896641042ff05af5c26fa3b575f5b02c840f6a96d
-size 5387927

--- a/datasets/DR5/DR5_nowarnings_less05_train.arff
+++ b/datasets/DR5/DR5_nowarnings_less05_train.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c435d98a81a89b27678f74bb7df6617d48c18e5580f127d637b46a294176f057
-size 33395344

--- a/datasets/DR5/README.txt
+++ b/datasets/DR5/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f14e6f33173e82b8bdbc852d895a75866a6139868176121fc6272301a4e7c08c
-size 1347

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7d6a27aebf16f1f0faf11135b74fdda90465610b121920257f23f3d59e641e98
-size 398

--- a/datasets/bupa_liver/README.txt
+++ b/datasets/bupa_liver/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:397a4aafaac7ff164c6266a58f7da5d55a6f54a9057a56389c3819d86a6c3fca
-size 365

--- a/datasets/bupa_liver/bupa.data
+++ b/datasets/bupa_liver/bupa.data
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a166a3e7a6f4dc41aaaedc59a107e57d8adcaeb8821f0873d756982f1ea74c92
-size 7297

--- a/datasets/bupa_liver/bupa.names
+++ b/datasets/bupa_liver/bupa.names
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8c348733ec58bd1cb489a5307409f60226b9afa30fd99b24fb593e9abc08dfe
-size 1272

--- a/datasets/bupa_liver/liver-disorders.arff.gz
+++ b/datasets/bupa_liver/liver-disorders.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:112f27195275917e2835fcc96d67a0a3ee7b7ce7b693668573b3b2f66f72fc08
-size 2583

--- a/datasets/bupa_liver/liver-disorders_normalized.arff.gz
+++ b/datasets/bupa_liver/liver-disorders_normalized.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b6ac02a13057e3363780a3b408493e1c17abd20357ba5d41dc472898df50ba1
-size 4584

--- a/datasets/chessboard/README.txt
+++ b/datasets/chessboard/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8de13366f50c51dc701efc81986ebd42af42faea81450e620f17a24f1bac60f2
-size 518

--- a/datasets/chessboard/chess.py
+++ b/datasets/chessboard/chess.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0bc39f49b4f8bca8f79c9ec19d1a68751105d38223187406476107905a5429c5
-size 973

--- a/datasets/chessboard/chess_4d_500000.arff
+++ b/datasets/chessboard/chess_4d_500000.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24d8126c528ae0d39b0817b8b6241df8456dc4e4d88abf3a0c485bd8457da0f2
-size 34249123

--- a/datasets/chessboard/create_20000tr10000te.sh
+++ b/datasets/chessboard/create_20000tr10000te.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c9a02e045a806efac7774f2255b15775ad845be423ff38a9078950a1a85c69d8
-size 2316

--- a/datasets/chessboard/create_dataset.py
+++ b/datasets/chessboard/create_dataset.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c09b5c3d611dbe39a1d37dbc525f6b4943c3acb14f97866162857e8962d7ef98
-size 2091

--- a/datasets/chessboard/create_scripts.py
+++ b/datasets/chessboard/create_scripts.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:56ce2225dcc3afa278f9599a9bd7c7551bbfca674e27f99fc07d607f2efa8c8e
-size 1060

--- a/datasets/chessboard/dat2arff.sh
+++ b/datasets/chessboard/dat2arff.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed88b1410b19e81aeeb3bfb61e67ee37f64a3cc0c8d0025013a1cb3d64b8d7f3
-size 1794

--- a/datasets/circle/README.txt
+++ b/datasets/circle/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a4caf919d0db03d0abf11e061c004049249475fc713c1479e0cf0b397883c81
-size 179

--- a/datasets/circle/circle.arff.gz
+++ b/datasets/circle/circle.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b407098139bf1ba451b00734d56d1ef2cc192b502125fd66f37333527cc9aa2
-size 4552

--- a/datasets/cube/README.txt
+++ b/datasets/cube/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f819929215c6f06412d126230817574b6c50eda45a32cdf03b25818dce01b76a
-size 755

--- a/datasets/cube/create_1000tr500te.sh
+++ b/datasets/cube/create_1000tr500te.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7fc8cc99ba5181b1e451d42d47e8a624483416ddb71974d001b07401c246f9b1
-size 6656

--- a/datasets/cube/create_dataset.py
+++ b/datasets/cube/create_dataset.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7357b7d678401fe8f9d1ae71b01d90d235f31214634a588e8f450a4a4ee0b10f
-size 1711

--- a/datasets/cube/create_scripts.py
+++ b/datasets/cube/create_scripts.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f53e35d5ea7d4fcc5dd56eb8da246d8245bd112d3f5aac6c6515692f11bab81
-size 826

--- a/datasets/cube/dat2arff.sh
+++ b/datasets/cube/dat2arff.sh
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8b589e4a33bd7c5f96269113d8ece64aaea9e85ed6c5b0c1b388b09b8b9a5cf
-size 5774

--- a/datasets/friedman/README.txt
+++ b/datasets/friedman/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c00d94f6d35b4733ada4275910cdee9e7f5bfdc7fcd44b414729a5f4cd7f9c7c
-size 1911

--- a/datasets/friedman/friedman.mod.py
+++ b/datasets/friedman/friedman.mod.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa658d0973b1116269cae80798febeb9a22dc3e3b07e13259c795799db0ca28d
-size 5127

--- a/datasets/friedman/friedman.py
+++ b/datasets/friedman/friedman.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3c2ed6802f722fc5569323ff28052d708308ae688289adf01ed083db030f0071
-size 3837

--- a/datasets/friedman/friedman1_10d_150000.arff
+++ b/datasets/friedman/friedman1_10d_150000.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e365aba9f581608bc271d210eb017a773721e521f872c504338b3de7ec59f1f
-size 24583350

--- a/datasets/friedman/friedman1_10d_500000.arff
+++ b/datasets/friedman/friedman1_10d_500000.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:197b7ce77fcadec1fa65e3d108b2a12df33275f8e8b6217a396436bdd30cbc36
-size 81943197

--- a/datasets/friedman/friedman2_4d.py
+++ b/datasets/friedman/friedman2_4d.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e639952450fff11c15e590246c2182fe878b08f33d93bef3ad381fda3fb30aea
-size 1486

--- a/datasets/friedman/friedman2_4d_300000.arff
+++ b/datasets/friedman/friedman2_4d_300000.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:198536febef97bf16f0de57118b624fa348e92b4f6842f6f15d6bf0040615634
-size 22186235

--- a/datasets/friedman/friedman2_4d_500000.arff
+++ b/datasets/friedman/friedman2_4d_500000.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ae9f50f837905c111cb779bd4ecbb3daac1cc9fe43ab59b1fcaed2299cce3872
-size 36976944

--- a/datasets/gutefrage/README
+++ b/datasets/gutefrage/README
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2e059e0345d5a9208d9d1850f61c6161035aff88a122cc872ad8c94ba16f83e3
-size 31

--- a/datasets/gutefrage/autofrage.json.gz
+++ b/datasets/gutefrage/autofrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65febd1ca1815e1baed90fb79c38497969649162377c3ca37ab0253175c9dfc4
-size 2298144

--- a/datasets/gutefrage/computerfrage.json.gz
+++ b/datasets/gutefrage/computerfrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a789b62096488f04311d600f84c392cf2c4d0c09351f74a28f743f64f9028c3d
-size 12545812

--- a/datasets/gutefrage/finanzfrage.json.gz
+++ b/datasets/gutefrage/finanzfrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff0289a057d3ebc0ee181c56cb0a20b5b781493b9b7e26dc8cab603ed1c6c1e2
-size 25377712

--- a/datasets/gutefrage/gesundheitsfrage.json.gz
+++ b/datasets/gutefrage/gesundheitsfrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:755d0c74fa17724d99bfd971f79d486a9142fe7523c82f4c8892951b75841f77
-size 25129812

--- a/datasets/gutefrage/gutefrage.json.gz
+++ b/datasets/gutefrage/gutefrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b73c19462e6f086129d53c437404f990fd2746afc8637b408faf2b3c3f1a83db
-size 3089874695

--- a/datasets/gutefrage/motorradfrage.json.gz
+++ b/datasets/gutefrage/motorradfrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96431263d8e1b7b56b96c0eed762cff1fd41b522120325022c5b1b35c71d169c
-size 6212535

--- a/datasets/gutefrage/reisefrage.json.gz
+++ b/datasets/gutefrage/reisefrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b96a2f0b0471766e313e3f777773f09a9415397bb292ef45875b6251c1dea8d
-size 9612533

--- a/datasets/gutefrage/sportlerfrage.json.gz
+++ b/datasets/gutefrage/sportlerfrage.json.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f2aa327f276643baf6323298ed1cbcb840176d97c28cbec0c32eb555907f3ae
-size 13675539

--- a/datasets/house_numbers/README.txt
+++ b/datasets/house_numbers/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea66a5c44d7108f767db88ca1ab2c11ec46e53a06b417f622744f33360deee65
-size 707

--- a/datasets/house_numbers/SVHN_8x8.tar.gz
+++ b/datasets/house_numbers/SVHN_8x8.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e19a0cc6df7a7758f7dfbf01b4be08845a66f4808316639a234c5faea72ae80e
-size 66594144

--- a/datasets/house_numbers/SVHN_Gray.test.arff.tar.gz
+++ b/datasets/house_numbers/SVHN_Gray.test.arff.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dfe7e4af221ea55ca7a740ad754b889371665723f3ac516f3f8d5689e532932c
-size 38808868

--- a/datasets/house_numbers/SVHN_Gray.train.arff.tar.gz
+++ b/datasets/house_numbers/SVHN_Gray.train.arff.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22f2af7fe9e5b0c3aa2958e81a65792836e852c976798488dca2d137c4cfe6b2
-size 111596555

--- a/datasets/house_numbers/SVHN_Gray_Coarse.test.arff.tar.gz
+++ b/datasets/house_numbers/SVHN_Gray_Coarse.test.arff.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8baa90f97dfb2d75dec370a4dede4350ab49a2f90386621d79d6af5fc86e6e13
-size 52940717

--- a/datasets/house_numbers/SVHN_Gray_Coarse.train.arff.tar.gz
+++ b/datasets/house_numbers/SVHN_Gray_Coarse.train.arff.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbe4b6171b162630bed136aa1b65833717805888d8751632962b52f898416687
-size 151729202

--- a/datasets/mnist/README.md
+++ b/datasets/mnist/README.md
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8a94c6a39838dd6369d8de7f3e71595e799aea0aedaa0edd78e05f34c1c5dd10
-size 490

--- a/datasets/mnist/t10k-images.idx3-ubyte
+++ b/datasets/mnist/t10k-images.idx3-ubyte
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0fa7898d509279e482958e8ce81c8e77db3f2f8254e26661ceb7762c4d494ce7
-size 7840016

--- a/datasets/mnist/t10k-labels.idx1-ubyte
+++ b/datasets/mnist/t10k-labels.idx1-ubyte
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ff7bcfd416de33731a308c3f266cc351222c34898ecbeaf847f06e48f7ec33f2
-size 10008

--- a/datasets/mnist/to_arff.py
+++ b/datasets/mnist/to_arff.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c07005be4a55d3ee72493521e2036e871b3d89adfdb94bfa27429e170ca3b7fb
-size 3465

--- a/datasets/mnist/train-images.idx3-ubyte
+++ b/datasets/mnist/train-images.idx3-ubyte
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba891046e6505d7aadcbbe25680a0738ad16aec93bde7f9b65e87a2fc25776db
-size 47040016

--- a/datasets/mnist/train-labels.idx1-ubyte
+++ b/datasets/mnist/train-labels.idx1-ubyte
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:65a50cbbf4e906d70832878ad85ccda5333a97f0f4c3dd2ef09a8a9eef7101c5
-size 60008

--- a/datasets/musk1/README.txt
+++ b/datasets/musk1/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:84eac819a28ab9d49123f0872923f4b0e0f8bf297e72f8b2e87b719177ce3ae4
-size 402

--- a/datasets/musk1/clean1.166.data.gz
+++ b/datasets/musk1/clean1.166.data.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:790daa6b5e641b62bfacaba160ba05072cb1f2eb6d4edd6acf6e3399539f2d2b
-size 110951

--- a/datasets/musk1/clean1.arff.gz
+++ b/datasets/musk1/clean1.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2cee2cfc4928fef5041a89133102efc91984fb3f821b30117b25fc3f3f7915fe
-size 346280

--- a/datasets/musk1/clean1.data.z
+++ b/datasets/musk1/clean1.data.z
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:433e42d012f3c0399abff545fcb4c24b35cd273b44105db176b319fc76421f95
-size 112953

--- a/datasets/musk1/clean1.info
+++ b/datasets/musk1/clean1.info
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:04202dcd23b727b4839081f3ceb70479d1c2c74cc987adbd9cdda9e50775e78d
-size 5680

--- a/datasets/musk1/clean1.names
+++ b/datasets/musk1/clean1.names
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41c5efc52b5f0fae6a6f3b730ead428b8f199d3ba1e2472ddf41e2036b2e1a5d
-size 7952

--- a/datasets/parabola/parabola.py
+++ b/datasets/parabola/parabola.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c770460ada6531db0e8c6321136c116f79e035b64b7000a209a3f924b60a21bb
-size 1074

--- a/datasets/parabola/parabolasimple.py
+++ b/datasets/parabola/parabolasimple.py
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8042a058b7e719f5e68ae1a4e0248de95376d2b5c80dd892a61c06e05b46064a
-size 1105

--- a/datasets/regression_artificial/1DLine/X.txt
+++ b/datasets/regression_artificial/1DLine/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:883273be51124af2904403dd9ba50b5e78c04419baa863e0b060820791e33737
-size 7401

--- a/datasets/regression_artificial/1DLine/Y.txt
+++ b/datasets/regression_artificial/1DLine/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:883273be51124af2904403dd9ba50b5e78c04419baa863e0b060820791e33737
-size 7401

--- a/datasets/regression_artificial/1DOption/X.txt
+++ b/datasets/regression_artificial/1DOption/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e375424bca19137f2b427717803482d683ff1fea85d225e5f157140439141bc
-size 7364

--- a/datasets/regression_artificial/1DOption/Y.txt
+++ b/datasets/regression_artificial/1DOption/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f35994c26bf4e09d56d890ae1d7540a07249cca99abb3f8f828093bec5fde47
-size 5316

--- a/datasets/regression_artificial/1DOption_1Y/X.txt
+++ b/datasets/regression_artificial/1DOption_1Y/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6bbcbd74341f94f426e60d9c93017774162c71cfcb88265857ef79326fbe9cad
-size 74276

--- a/datasets/regression_artificial/1DOption_1Y/Y.txt
+++ b/datasets/regression_artificial/1DOption_1Y/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:22c3d2ed2a7655f66be8c0bd3cf2220b1fb5b969ee9d96834a78a4c04e7b6647
-size 48008

--- a/datasets/regression_artificial/2DOption/X.txt
+++ b/datasets/regression_artificial/2DOption/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b41a0b4be3b7152138f581e24d104860ae4538ae31584c25b15f111366733216
-size 14791

--- a/datasets/regression_artificial/2DOption/Y.txt
+++ b/datasets/regression_artificial/2DOption/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3589ea6c13ec450e0633d701d909d8bacfafd1f77da895d2292526a9075b1a0c
-size 5323

--- a/datasets/regression_artificial/2DOption_1Y/X.txt
+++ b/datasets/regression_artificial/2DOption_1Y/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7bf929581f0af0536bd9b038a7aa27b0f9cc827b3995b0dfa160c4ee7d73b72
-size 148654

--- a/datasets/regression_artificial/2DOption_1Y/Y.txt
+++ b/datasets/regression_artificial/2DOption_1Y/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96d87c36cbc4a9c4d713a327ff4515c6c7454ee1d8380deac3c9d0166b196621
-size 48473

--- a/datasets/regression_artificial/2DPlane/X.txt
+++ b/datasets/regression_artificial/2DPlane/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea20af0d5e091397c99ea7c8a7ed72728e10e0e7d00266a60574437c1bbee939
-size 14746

--- a/datasets/regression_artificial/2DPlane/Y.txt
+++ b/datasets/regression_artificial/2DPlane/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:529965b637128d0cfbebbc840020ec5d63ca56a42b4edf392ae6a6c051e7da34
-size 6897

--- a/datasets/regression_artificial/3DOption/X.txt
+++ b/datasets/regression_artificial/3DOption/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:66084b0fba5f40c66271199c8625a080638910cd221b69b5535277bff876e898
-size 66459

--- a/datasets/regression_artificial/3DOption/Y.txt
+++ b/datasets/regression_artificial/3DOption/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09a40962995271ff28040bb06612005c51609ce9b312ab284366311e64cdc323
-size 16159

--- a/datasets/regression_artificial/3DPlane/X.txt
+++ b/datasets/regression_artificial/3DPlane/X.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4479e4d6334787e9de5b62d6e3c0b4305cf821824dcc27224b0997e5a63d7edd
-size 66405

--- a/datasets/regression_artificial/3DPlane/Y.txt
+++ b/datasets/regression_artificial/3DPlane/Y.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cc377d8f72b400504b4df91758b65641394964f1c0f4d7b58d340234d474335a
-size 20684

--- a/datasets/ripley/README.txt
+++ b/datasets/ripley/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f155a5415cbb2214bc64a3f35c5a102d3dfaf77549a6b12923c11c6455157596
-size 448

--- a/datasets/ripley/ripleyGarcke.test
+++ b/datasets/ripley/ripleyGarcke.test
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:01b77d980905764fb8e4e737f54d1ef76360bb2db6a123bdb9d193beb9400055
-size 20500

--- a/datasets/ripley/ripleyGarcke.test.arff
+++ b/datasets/ripley/ripleyGarcke.test.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4f1d5cd7217121e25d362cef8addc9f7c67d11f5f8f32b4de7059bf7719b2f8f
-size 22360

--- a/datasets/ripley/ripleyGarcke.test.arff.gz
+++ b/datasets/ripley/ripleyGarcke.test.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db62f09e3eb1daa124c173adf6de6fef66614560b096d4ee2df12ec6fff4cfb7
-size 8217

--- a/datasets/ripley/ripleyGarcke.train
+++ b/datasets/ripley/ripleyGarcke.train
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9eda5c10dd17eb190e1d2d797919338ee62a405f8a345d6a48c6306f94bb9526
-size 5125

--- a/datasets/ripley/ripleyGarcke.train.arff
+++ b/datasets/ripley/ripleyGarcke.train.arff
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc445bb86a9c06687c1b1f78be0b1d739df67d5e1820f7293b9ca0667f3b8613
-size 5673

--- a/datasets/ripley/ripleyGarcke.train.arff.gz
+++ b/datasets/ripley/ripleyGarcke.train.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d51608cd3bdfb578e1ad5dbfa06177a2c6d9822cb740009bd088414acdd871e
-size 2279

--- a/datasets/ripley/synth.te
+++ b/datasets/ripley/synth.te
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2613336c967be84b57ee75bbc1a0ee0890e32a72ae0e0784fddf76426a226846
-size 32032

--- a/datasets/ripley/synth.tr
+++ b/datasets/ripley/synth.tr
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0d3bbce9af4bfc22d5f225d903808e113638569b1751a4890feb02275005526
-size 7530

--- a/datasets/twospirals/README.txt
+++ b/datasets/twospirals/README.txt
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c37b580d9a03a48403cf99867173c22d02b07a7649cb9f75ba10ee97b9cca4b0
-size 373

--- a/datasets/twospirals/twospirals.data
+++ b/datasets/twospirals/twospirals.data
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d83699a68f4f41a26b077747963586e0985a17b3b308ba1cf78435e301c817b
-size 10875

--- a/datasets/twospirals/twospirals.wieland.arff.gz
+++ b/datasets/twospirals/twospirals.wieland.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1aa99b74f45fb814dfe4a0955274ca7fa3fa288900eff7b4c7dc63a570745a24
-size 1957

--- a/datasets/twospirals/twospirals.wieland.b0.0625.arff.gz
+++ b/datasets/twospirals/twospirals.wieland.b0.0625.arff.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5b917cc40d5efd3a49d0779edafc950ebaa1513432532d45a998c17250aaae67
-size 2273

--- a/datasets/twospirals/twospirals.wieland.dat
+++ b/datasets/twospirals/twospirals.wieland.dat
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:05d0da98985f398d8a542db012b25f64a911c7ce0c20f16b85a0a18855efcb9e
-size 6693


### PR DESCRIPTION
We can't checkout the repo otherwise. Datasets are now in separate repo on GitLab.