### PR TITLE
Detect zlib

### DIFF
--- a/base/doc/doxygen/linux.doxy
+++ b/base/doc/doxygen/linux.doxy
@@ -76,6 +76,8 @@ The following software can be installed for full functionality:
   can be used in conjunction with the <tt>SG_OPTIMIZATION</tt> module.
 - <a href="https://dakota.sandia.gov/">DAKOTA</a> is required for the Polynomial Chaos Expansion functionalities of the <tt>SG_COMBIGRID</tt> module. [Installation instructions](@ref install_dakota) 
 - <a href="https://www.cgal.org/index.html">CGAL</a> is required for a new Sparse Grid Density Estimation of the <tt>SG_DATADRIVEN</tt> module. It is required to solve a quadratic optimization problem to guarantee positive function values at the grid points.
+- <a href="https://www.zlib.net/" target="_blank">zlib</a>
+  is recommended for the <tt>SG_DATADRIVEN</tt> module.
 
 @subsection linux_dependencies_installation Installation
 

--- a/datadriven/SConscript
+++ b/datadriven/SConscript
@@ -17,6 +17,7 @@ additionalBoostTestDependencies = []
 
 if env["USE_ZLIB"]:
   additionalDependencies += ["z"]
+  additionalBoostTestDependencies = ["z"]
 if env["USE_OCL"]:
   additionalDependencies += ["OpenCL"]
 if env["USE_GSL"]:
@@ -24,7 +25,6 @@ if env["USE_GSL"]:
 if env["USE_CGAL"]:
   additionalDependencies += ["CGAL"]
 
-additionalBoostTestDependencies = ["z"]
 performanceTestFlag = "COMPILE_BOOST_PERFORMANCE_TESTS"
 performanceTestRunFlag = "RUN_BOOST_PERFORMANCE_TESTS"
 

--- a/datadriven/performanceTests/multiEvalAutoTuningPaper.cpp
+++ b/datadriven/performanceTests/multiEvalAutoTuningPaper.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -1022,4 +1023,5 @@ BOOST_AUTO_TEST_CASE(StreamingIntrinsicsComparison) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/performanceTests/multiEvalLinearTest.cpp
+++ b/datadriven/performanceTests/multiEvalLinearTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -776,4 +777,5 @@ BOOST_AUTO_TEST_CASE(StreamingOCLMask) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/performanceTests/testsCommon.cpp
+++ b/datadriven/performanceTests/testsCommon.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #include <boost/lexical_cast.hpp>
 #include <zlib.h>
 
@@ -102,3 +104,5 @@ void doDirectedRefinements(sgpp::base::AdaptivityConfiguration& adaptConfig, sgp
     dummySurplusValue += 1.0;
   }
 }
+
+#endif

--- a/datadriven/tests/densityClustering.cpp
+++ b/datadriven/tests/densityClustering.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -606,4 +607,5 @@ BOOST_AUTO_TEST_CASE(KNNClusterSearch) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+#endif
 #endif

--- a/datadriven/tests/streamingModMaskMultTest.cpp
+++ b/datadriven/tests/streamingModMaskMultTest.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #define BOOST_TEST_DYN_LINK
 #include <zlib.h>
 #include <boost/test/unit_test.hpp>
@@ -48,3 +50,5 @@ BOOST_AUTO_TEST_CASE(Simple) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/datadriven/tests/streamingModMaskMultTransposeTest.cpp
+++ b/datadriven/tests/streamingModMaskMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #ifdef __AVX__
 
 #define BOOST_TEST_DYN_LINK
@@ -52,4 +53,5 @@ BOOST_AUTO_TEST_CASE(Simple) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLFastMultiPlatformMultTest.cpp
+++ b/datadriven/tests/streamingModOCLFastMultiPlatformMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -231,4 +232,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLFastMultiPlatformMultTransposeTest.cpp
+++ b/datadriven/tests/streamingModOCLFastMultiPlatformMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -247,4 +248,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLMaskMultiPlatformMultTest.cpp
+++ b/datadriven/tests/streamingModOCLMaskMultiPlatformMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -247,4 +248,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLMaskMultiPlatformMultTransposeTest.cpp
+++ b/datadriven/tests/streamingModOCLMaskMultiPlatformMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -258,4 +259,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLOptMultTest.cpp
+++ b/datadriven/tests/streamingModOCLOptMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -247,4 +248,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingModOCLOptMultTransposeTest.cpp
+++ b/datadriven/tests/streamingModOCLOptMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -257,4 +258,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingMultTest.cpp
+++ b/datadriven/tests/streamingMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #ifdef __AVX__
 
 #define BOOST_TEST_DYN_LINK
@@ -50,4 +51,5 @@ BOOST_AUTO_TEST_CASE(Simple) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingMultTransposeTest.cpp
+++ b/datadriven/tests/streamingMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #ifdef __AVX__
 
 #define BOOST_TEST_DYN_LINK
@@ -52,4 +53,5 @@ BOOST_AUTO_TEST_CASE(Simple) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingOCLMultiPlatformMultTest.cpp
+++ b/datadriven/tests/streamingOCLMultiPlatformMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -223,4 +224,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingOCLMultiPlatformMultTransposeTest.cpp
+++ b/datadriven/tests/streamingOCLMultiPlatformMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 
 #define BOOST_TEST_DYN_LINK
@@ -228,4 +229,5 @@ BOOST_AUTO_TEST_CASE(MultiPlatformSinglePrecision) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif

--- a/datadriven/tests/streamingSubspaceCombinedMultTest.cpp
+++ b/datadriven/tests/streamingSubspaceCombinedMultTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 #ifdef __AVX__
 
@@ -52,5 +53,6 @@ BOOST_AUTO_TEST_CASE(Simple) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif
 #endif

--- a/datadriven/tests/streamingSubspaceCombinedMultTransposeTest.cpp
+++ b/datadriven/tests/streamingSubspaceCombinedMultTransposeTest.cpp
@@ -3,6 +3,7 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
 #if USE_OCL == 1
 #ifdef __AVX__
 
@@ -54,5 +55,6 @@ BOOST_AUTO_TEST_CASE(Simple) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+#endif
 #endif
 #endif

--- a/datadriven/tests/testBBT.cpp
+++ b/datadriven/tests/testBBT.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
@@ -730,3 +732,4 @@ BOOST_AUTO_TEST_CASE(testOperationTest_test) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/datadriven/tests/testBT.cpp
+++ b/datadriven/tests/testBT.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 #include <boost/lexical_cast.hpp>
@@ -514,3 +516,5 @@ BOOST_AUTO_TEST_CASE(testHatRegulardD_two) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/datadriven/tests/test_datadrivenCommon.cpp
+++ b/datadriven/tests/test_datadrivenCommon.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #include <zlib.h>
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
@@ -398,4 +400,5 @@ std::shared_ptr<OCLOperationConfiguration> getConfigurationDefaultsMultiPlatform
   auto parameters = manager.getConfiguration();
   return parameters;
 }
+#endif
 #endif

--- a/misc/SConscript
+++ b/misc/SConscript
@@ -8,7 +8,12 @@ import ModuleHelper
 Import("*")
 
 moduleDependencies = ["sgppdatadriven", "sgppoptimization", "sgpppde", "sgppsolver", "sgppbase"]
-module = ModuleHelper.Module(moduleDependencies, additionalBoostTestDependencies=["z"])
+additionalBoostTestDependencies = []
+
+if env["USE_ZLIB"]:
+  additionalBoostTestDependencies = ["z"]
+
+module = ModuleHelper.Module(moduleDependencies, additionalBoostTestDependencies)
 
 module.scanSource()
 module.buildLibrary()

--- a/misc/tests/test_dummy.cpp
+++ b/misc/tests/test_dummy.cpp
@@ -1,0 +1,15 @@
+// Copyright (C) 2008-today The SG++ project
+// This file is part of the SG++ project. For conditions of distribution and
+// use, please see the copyright notice provided with SG++ or at
+// sgpp.sparsegrids.org
+
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(TestDummy)
+
+BOOST_AUTO_TEST_CASE(testDummy1) {
+  BOOST_CHECK_EQUAL(1, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/misc/tests/test_laplace.cpp
+++ b/misc/tests/test_laplace.cpp
@@ -3,6 +3,8 @@
 // use, please see the copyright notice provided with SG++ or at
 // sgpp.sparsegrids.org
 
+#ifdef ZLIB
+
 #define BOOST_TEST_DYN_LINK
 #include <boost/lexical_cast.hpp>
 #include <boost/test/unit_test.hpp>
@@ -691,3 +693,4 @@ BOOST_AUTO_TEST_CASE(testPrewaveletAdaptiveD_two) {
   compareStiffnessMatrices(&m, mRef.get());
 }
 BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -101,7 +101,8 @@ def doConfigure(env, moduleFolders, languageWrapperFolders):
     checkDoxygen(config)
     checkDot(config)
   checkOpenCL(config)
-  checkZlib(config)
+  #checkZlib(config)
+  detectZlib(config)
   checkGSL(config)
   checkDAKOTA(config)
   checkCGAL(config)
@@ -594,3 +595,18 @@ def configureIntelCompiler(config):
                              "Available configurations are: sse3, sse4.2, avx, avx2, avx512, mic")
 
   config.env.AppendUnique(CPPPATH=[distutils.sysconfig.get_python_inc()])
+
+def detectZlib(config):
+  has_libz = config.CheckLib("z", language="c++", autoadd=0)
+  has_zlib = config.CheckCXXHeader("zlib.h")
+  if has_libz and has_zlib:
+    Helper.printInfo("zlib is installed, enabling ZLIB support.")
+    config.env["USE_ZLIB"] = True
+    config.env["CPPDEFINES"]["ZLIB"] = "1"
+  elif config.env["USE_ZLIB"]:
+    if config.env["PLATFORM"] == "win32":
+      Helper.printWarning("zlib is currently not supported on Windows. Continuing withouth zlib.")
+    else:
+      Helper.printErrorAndExit("USE_ZLIB is set but either libz or zlib.h is missing!")
+  else:
+    Helper.printInfo("ZLIB support could not be enabled.")

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -101,7 +101,6 @@ def doConfigure(env, moduleFolders, languageWrapperFolders):
     checkDoxygen(config)
     checkDot(config)
   checkOpenCL(config)
-  #checkZlib(config)
   detectZlib(config)
   checkGSL(config)
   checkDAKOTA(config)
@@ -263,17 +262,6 @@ def checkGSL(config):
       Helper.printErrorAndExit("libsgl/libgslcblas not found, but required for GSL")
 
     config.env["CPPDEFINES"]["USE_GSL"] = "1"
-
-def checkZlib(config):
-#zlib needed for datamining
-    if(config.env["USE_ZLIB"]):
-        if config.env["PLATFORM"] == "win32":
-            Helper.printWarning("zlib is currently not supported on Windows. Continuing withouth zlib.")
-        else:
-            if not config.CheckLibWithHeader("z","zlib.h", language="C++",autoadd=0):
-                Helper.printErrorAndExit("The flag USE_ZLIB was set, but the necessary header 'zlib.h' or library was not found.")
-
-            config.env["CPPDEFINES"]["ZLIB"] = "1"
 
 def checkBoostTests(config):
   # Check the availability of the boost unit test dependencies
@@ -597,9 +585,7 @@ def configureIntelCompiler(config):
   config.env.AppendUnique(CPPPATH=[distutils.sysconfig.get_python_inc()])
 
 def detectZlib(config):
-  has_libz = config.CheckLib("z", language="c++", autoadd=0)
-  has_zlib = config.CheckCXXHeader("zlib.h")
-  if has_libz and has_zlib:
+  if config.CheckLib("z", language="c++", autoadd=0) and config.CheckCXXHeader("zlib.h"):
     Helper.printInfo("zlib is installed, enabling ZLIB support.")
     config.env["USE_ZLIB"] = True
     config.env["CPPDEFINES"]["ZLIB"] = "1"


### PR DESCRIPTION
This PR introduces automatic detection of zlib headers and libraries and enables the zlib features if possible.
Also checks are introduced before headers are included in all cases and zlib installation for linux is documented.