### PR TITLE
Fix datadriven tests

### DIFF
--- a/datadriven/tests/HPOTest.cpp
+++ b/datadriven/tests/HPOTest.cpp
@@ -119,7 +119,7 @@ class HarmonicaTester : public sgpp::datadriven::Harmonica {
 
 BOOST_AUTO_TEST_CASE(upperLevelTest) {
   // using actual files for (dummy) data and config
-  std::string path("datadriven/test/hpo_testconfig.json");
+  std::string path("datadriven/tests/hpo_testconfig.json");
   sgpp::datadriven::DataMiningConfigParser parser(path);
   // sgpp::datadriven::DataSourceBuilder builder;
   // sgpp::datadriven::DataSourceConfig config;

--- a/optimization/src/sgpp/optimization/optimizer/unconstrained/MultiStart.cpp
+++ b/optimization/src/sgpp/optimization/optimizer/unconstrained/MultiStart.cpp
@@ -195,9 +195,12 @@ void MultiStart::optimize() {
         Printer::getInstance().getMutex().unlock();
       }
 
-      xHist.appendRow(xCurrentOpt);
-      fHist.append(fCurrentOpt);
-      kHist.push_back(curOptimizerPtr->getHistoryOfOptimalPoints().getNrows());
+#pragma omp critical
+      {
+        xHist.appendRow(xCurrentOpt);
+        fHist.append(fCurrentOpt);
+        kHist.push_back(curOptimizerPtr->getHistoryOfOptimalPoints().getNrows());
+      }
     }
   }
 


### PR DESCRIPTION
This should fix two fatal errors in `test_datadriven_boost/HPOTest/upperLevelTest`. One is related to a wrong test filename and the other to an OpenMP race condition. Jenkins fails on current `master` because of this.