### PR TITLE
Fixes the doxygen generation of images for different grid types

### DIFF
--- a/base/doc/doxygen_html_style.css
+++ b/base/doc/doxygen_html_style.css
@@ -1,6 +1,150 @@
+div.image img[src="createLinearGridStencil_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="createModLinearGridStencil_C2J-small.png"]{
+    height:200px;
+}
 div.image img[src="createLinearGrid_C2J-small.png"]{
     height:200px;
 }
 div.image img[src="hiba_createLinearGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createLinearStretchedGrid_C2J-small.png"]{
     height:200px;
+}
+div.image img[src="hiba_createLinearStretchedGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createLinearBoundaryGrid_C2,_0J-small.png"]{
+    height:200px;
+}
+div.image img[src="createLinearBoundaryGrid_C2,_1J-small.png"]{
+    height:200px;
+}
+div.image img[src="createLinearBoundaryGrid_C2,_2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createLinearGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createLinearStretchedBoundaryGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createLinearStretchedBoundaryGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createLinearClenshawCurtisGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createLinearClenshawCurtisGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModLinearGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModLinearGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createPolyGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createPolyGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createPolyBoundaryGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createPolyBoundaryGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModPolyGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModPolyGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createWaveletGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createWaveletGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createWaveletBoundaryGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createWaveletBoundaryGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModWaveletGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModWaveletGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createBsplineGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createBsplineGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createBsplineBoundaryGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createBsplineBoundaryGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createBsplineClenshawCurtisGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createBsplineClenshawCurtisGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModBsplineGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModBsplineGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModBsplineClenshawCurtisGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModBsplineClenshawCurtisGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createFundamentalSplineGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createFundamentalSplineGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createModFundamentalSplineGrid_C2,_3J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createModFundamentalSplineGrid_C2,_3J-small.png"]{
+    width:200px;
+}
+div.image img[src="createPrewaveletGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createPrewaveletGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createSquareRootGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createSquareRootGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createLinearTruncatedBoundaryGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createLinearTruncatedBoundaryGrid_C2J-small.png"]{
+    width:200px;
+}
+div.image img[src="createPeriodicGrid_C2J-small.png"]{
+    height:200px;
+}
+div.image img[src="hiba_createPeriodicGrid_C2J-small.png"]{
+    width:200px;
 }

--- a/base/src/sgpp/base/grid/Grid.hpp
+++ b/base/src/sgpp/base/grid/Grid.hpp
@@ -174,9 +174,7 @@ class Grid {
    * creates a stencil for a linear grid (without boundaries)
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearGridStencil_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
+   * <td>\image html "createLinearGridStencil_C2J-small.png" "Level 4 sparse grid"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -188,9 +186,7 @@ class Grid {
    * creates a stencil for a modified linear grid (without boundaries)
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModLinearGridStencil_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
+   * <td>\image html "createModLinearGridStencil_C2J-small.png" "Level 4 sparse grid"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -203,10 +199,8 @@ class Grid {
    * piecewise linear basis functions
    *
    * <table border="0"><tr>
-   * <td>\image html createLinearGrid_C2J-small.png "Level
-   * 4 sparse grid"</td>
-   * <td>\image html hiba_createLinearGrid_C2J-small.png "Hierarchical
-   * basis functions up to level 3"</td>
+   * <td>\image html "createLinearGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createLinearGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -218,12 +212,8 @@ class Grid {
    * creates a linear stretched grid without boundaries
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearStretchedGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createLinearStretchedGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createLinearStretchedGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createLinearStretchedGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -233,19 +223,11 @@ class Grid {
 
   /**
    * creates a linear boundary grid
-   *
-    <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearBoundaryGrid_C2,_0J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid with boundaryLevel = 0</div></div></td>
-   * <td><div class="image">
-   * <img src="createLinearBoundaryGrid_C2,_1J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid with boundaryLevel = 1</div></div></td>
-   * <td><div class="image">
-   * <img src="createLinearBoundaryGrid_C2,_2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid with boundaryLevel = 2</div></div></td>
-   * <td><div class="image"><img src="hiba_createLinearGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <table border="0"><tr>
+   * <td>\image html "createLinearBoundaryGrid_C2,_0J-small.png" "Level 4 sparse grid with boundaryLevel = 0"</td>
+   * <td>\image html "createLinearBoundaryGrid_C2,_1J-small.png" "Level 4 sparse grid with boundaryLevel = 1"</td>
+   * <td>\image html "createLinearBoundaryGrid_C2,_2J-small.png" "Level 4 sparse grid with boundaryLevel = 2"</td>
+   * <td>\image html "hiba_createLinearGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -262,12 +244,8 @@ class Grid {
    * creates a linearstretched truncated boundary grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearStretchedBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createLinearStretchedBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createLinearStretchedBoundaryGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createLinearStretchedBoundaryGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -287,12 +265,8 @@ class Grid {
    * creates a linear Clenshaw-Curtis grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearClenshawCurtisGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createLinearClenshawCurtisGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createLinearClenshawCurtisGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createLinearClenshawCurtisGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -312,12 +286,8 @@ class Grid {
    * creates a modified linear grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModLinearGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModLinearGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModLinearGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModLinearGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -329,12 +299,8 @@ class Grid {
    * creates a polynomial grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createPolyGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createPolyGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createPolyGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createPolyGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -347,12 +313,8 @@ class Grid {
    * creates a polynomial grid with truncated boundary
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createPolyBoundaryGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createPolyBoundaryGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createPolyBoundaryGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createPolyBoundaryGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -395,12 +357,8 @@ class Grid {
    * creates a modified polynomial grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModPolyGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModPolyGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModPolyGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModPolyGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -413,12 +371,8 @@ class Grid {
    * creates a wavelet grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createWaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createWaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createWaveletGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createWaveletGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -430,12 +384,8 @@ class Grid {
    * creates a wavelet trapezoid boundary grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createWaveletBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createWaveletBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createWaveletBoundaryGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createWaveletBoundaryGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -446,12 +396,8 @@ class Grid {
    * creates a modified wavelet grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModWaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModWaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModWaveletGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModWaveletGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -463,12 +409,8 @@ class Grid {
    * creates a B-spline grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createBsplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createBsplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createBsplineGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createBsplineGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -481,12 +423,8 @@ class Grid {
    * creates a B-spline trapezoid boundary grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createBsplineBoundaryGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createBsplineBoundaryGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createBsplineBoundaryGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createBsplineBoundaryGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -499,12 +437,8 @@ class Grid {
    * creates a B-spline Clenshaw-Curtis grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createBsplineClenshawCurtisGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createBsplineClenshawCurtisGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createBsplineClenshawCurtisGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createBsplineClenshawCurtisGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -517,12 +451,8 @@ class Grid {
    * creates a modified B-spline grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModBsplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModBsplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModBsplineGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModBsplineGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -535,12 +465,8 @@ class Grid {
    * creates a modified B-spline Clenshaw-Curtis grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModBsplineClenshawCurtisGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModBsplineClenshawCurtisGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModBsplineClenshawCurtisGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModBsplineClenshawCurtisGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -553,12 +479,8 @@ class Grid {
    * creates a fundamental spline grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createFundamentalSplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createFundamentalSplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createFundamentalSplineGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createFundamentalSplineGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -571,12 +493,8 @@ class Grid {
    * creates a modified fundamental spline grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createModFundamentalSplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createModFundamentalSplineGrid_C2,_3J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createModFundamentalSplineGrid_C2,_3J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createModFundamentalSplineGrid_C2,_3J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -589,12 +507,8 @@ class Grid {
    * creates a prewavelet grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createPrewaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createPrewaveletGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createPrewaveletGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createPrewaveletGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -606,12 +520,8 @@ class Grid {
    * creates a square root grid (h-grid)
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createSquareRootGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createSquareRootGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createSquareRootGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createSquareRootGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -624,12 +534,8 @@ class Grid {
    * \f$|l|<level and li>=l_user\f$
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createLinearTruncatedBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createLinearTruncatedBoundaryGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createLinearTruncatedBoundaryGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createLinearTruncatedBoundaryGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension
@@ -641,12 +547,8 @@ class Grid {
    * creates a periodic grid
    *
    * <table border="0"><tr>
-   * <td><div class="image">
-   * <img src="createPeriodicGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Level 4 sparse grid</div></div></td>
-   * <td><div class="image">
-   * <img src="hiba_createPeriodicGrid_C2J-small.png" height="200px"/>
-   * <div class="caption">Hierarchical basis functions up to level 3</div></div></td>
+   * <td>\image html "createPeriodicGrid_C2J-small.png" "Level 4 sparse grid"</td>
+   * <td>\image html "hiba_createPeriodicGrid_C2J-small.png" "Hierarchical basis functions up to level 3"</td>
    * </tr></table>
    *
    * @param dim the grid's dimension

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -4497,7 +4497,8 @@ def CheckStyle(filename, clean_lines, linenum, file_extension, nesting_state,
   # developers fault.
   if (not line.startswith('#include') and not is_header_guard and
       not Match(r'^\s*//.*http(s?)://\S*$', line) and
-      not Match(r'^// \$Id:.*#[0-9]+ \$$', line)):
+      not Match(r'^// \$Id:.*#[0-9]+ \$$', line) and
+      not Match(r'^\s* <td>\image', line)):
     line_width = GetLineWidth(line)
     extended_length = int((_line_length * 1.25))
     if line_width > extended_length:


### PR DESCRIPTION
This is based on an older merge request from Gitlab that didn't get merged at a previous instance of the Coding Days (see original discussion in #42 )

Changes are basically:
- a new `.css` style file, further extendable if needed
- a minor and very specific rule exception in `cpplint.py`
- changes to the comment lines for each grid type for which we want to have images in the documentation

Before merging, a second check that the images are shown properly in the online documentation would be helpful (preferably as part of the mandatory review process, to lower verbosity :smile: )

P.S.: As all changes were done basically independent of everything else and in one single commit, I chose this time to rebase master instead of merging as usual, to keep git history nice and clean :wink: 