### PR TITLE
Dima l2 refine

### DIFF
--- a/datadriven/examplesPipeline/classificationMinerConfig.json
+++ b/datadriven/examplesPipeline/classificationMinerConfig.json
@@ -35,7 +35,8 @@
 			"lambda": 1e-2
 		},
 		"densityEstimationConfig" : {
-			"densityEstimationType" : "decomposition"
+			"densityEstimationType" : "decomposition",
+			"matrixDecompositionType" : "chol"
 		},
 		"learner" : {
 			"usePrior" : true,

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
@@ -188,9 +188,8 @@ void DBMatOffline::compute_L2_refine_vectors(DataMatrix* mat_refine, Grid* grid,
     auto opLTwoLin = new sgpp::pde::OperationMatrixLTwoDotExplicitLinear();
     opLTwoLin->buildMatrixWithBounds(mat_refine, grid, 0, 0, j_start, 0);
   } else if (grid->getType() == sgpp::base::GridType::ModLinear) {
-    throw algorithm_exception("modlinear noch nicht supported, bruh!");
-    // auto opLTwoModLin = new sgpp::pde::OperationMatrixLTwoDotExplicitLinear();
-    // opLTwoModLin->buildMatrixWithBounds(mat_refine, grid);
+    auto opLTwoModLin = new sgpp::pde::OperationMatrixLTwoDotExplicitLinear();
+    opLTwoModLin->buildMatrixWithBounds(mat_refine, grid, 0, 0, j_start, 0);
   } else {
     throw algorithm_exception(
         "in DBMatOffline::compute_L2_refine_vectors, gridType is not supported.");

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
@@ -180,8 +180,21 @@ void DBMatOffline::printMatrix() {
   }
 }
 
-void DBMatOffline::compute_L2_refine_vectors(DataMatrix& mat_refine, Grid& grid, size_t newPoints) {
+void DBMatOffline::compute_L2_refine_vectors(DataMatrix* mat_refine, Grid* grid, size_t newPoints) {
+  size_t j_start = grid->getSize() - newPoints;
 
+  // todo: switch-case when adding support for other gridTypes
+  if (grid->getType() == sgpp::base::GridType::Linear) {
+    auto opLTwoLin = new sgpp::pde::OperationMatrixLTwoDotExplicitLinear();
+    opLTwoLin->buildMatrixWithBounds(mat_refine, grid, 0, 0, j_start, 0);
+  } else if (grid->getType() == sgpp::base::GridType::ModLinear) {
+    throw algorithm_exception("modlinear noch nicht supported, bruh!");
+    // auto opLTwoModLin = new sgpp::pde::OperationMatrixLTwoDotExplicitLinear();
+    // opLTwoModLin->buildMatrixWithBounds(mat_refine, grid);
+  } else {
+    throw algorithm_exception(
+        "in DBMatOffline::compute_L2_refine_vectors, gridType is not supported.");
+  }
 }
 
 void sgpp::datadriven::DBMatOffline::parseInter(

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.cpp
@@ -180,6 +180,10 @@ void DBMatOffline::printMatrix() {
   }
 }
 
+void DBMatOffline::compute_L2_refine_vectors(DataMatrix& mat_refine, Grid& grid, size_t newPoints) {
+
+}
+
 void sgpp::datadriven::DBMatOffline::parseInter(
     const std::string& fileName, std::vector<std::vector<size_t>>& interactions) const {
   std::ifstream file(fileName, std::istream::in);

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
@@ -11,6 +11,7 @@
 #include <sgpp/datadriven/configuration/RegularizationConfiguration.hpp>
 #include <sgpp/datadriven/scalapack/BlacsProcessGrid.hpp>
 #include <sgpp/datadriven/scalapack/DataMatrixDistributed.hpp>
+#include <sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp>
 
 #include <list>
 #include <memory>
@@ -138,7 +139,7 @@ class DBMatOffline {
    * @param grid underlying grid
    * @param newPoints amount of points to refine
    */
-  void compute_L2_refine_vectors(DataMatrix& mat_refine, Grid& grid, size_t newPoints);
+  void compute_L2_refine_vectors(DataMatrix* mat_refine, Grid* grid, size_t newPoints);
 
   /**
    * Serialize the DBMatOffline Object

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
@@ -12,6 +12,7 @@
 #include <sgpp/datadriven/scalapack/BlacsProcessGrid.hpp>
 #include <sgpp/datadriven/scalapack/DataMatrixDistributed.hpp>
 #include <sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp>
+#include <sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.hpp>
 
 #include <list>
 #include <memory>

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOffline.hpp
@@ -133,6 +133,14 @@ class DBMatOffline {
   void printMatrix();
 
   /**
+   * computes vectors of L2 products of grid points for refinement
+   * @param mat_refine matrix to store L2 vectors
+   * @param grid underlying grid
+   * @param newPoints amount of points to refine
+   */
+  void compute_L2_refine_vectors(DataMatrix& mat_refine, Grid& grid, size_t newPoints);
+
+  /**
    * Serialize the DBMatOffline Object
    * @param fileName path where to store the file.
    */

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOfflineChol.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOfflineChol.cpp
@@ -32,9 +32,9 @@
 namespace sgpp {
 namespace datadriven {
 
+using sgpp::base::algorithm_exception;
 using sgpp::base::DataMatrix;
 using sgpp::base::DataVector;
-using sgpp::base::algorithm_exception;
 
 DBMatOfflineChol::DBMatOfflineChol() : DBMatOfflineGE() {}
 
@@ -45,7 +45,7 @@ DBMatOffline* DBMatOfflineChol::clone() { return new DBMatOfflineChol{*this}; }
 bool DBMatOfflineChol::isRefineable() { return true; }
 
 void DBMatOfflineChol::decomposeMatrix(RegularizationConfiguration& regularizationConfig,
-    DensityEstimationConfiguration& densityEstimationConfig) {
+                                       DensityEstimationConfiguration& densityEstimationConfig) {
 #ifdef USE_GSL
   if (isConstructed) {
     if (isDecomposed) {
@@ -82,9 +82,9 @@ void DBMatOfflineChol::decomposeMatrix(RegularizationConfiguration& regularizati
 #endif /*USE_GSL*/
 }
 
-void DBMatOfflineChol::choleskyModification(Grid& grid,
-    datadriven::DensityEstimationConfiguration&, size_t newPoints,
-    std::list<size_t> deletedPoints, double lambda) {
+void DBMatOfflineChol::choleskyModification(Grid& grid, datadriven::DensityEstimationConfiguration&,
+                                            size_t newPoints, std::list<size_t> deletedPoints,
+                                            double lambda) {
 #ifdef USE_GSL
 
   // Start coarsening
@@ -157,6 +157,7 @@ void DBMatOfflineChol::choleskyModification(Grid& grid,
     }
   }
 
+  // Start refinement
   // Start refinement
   if (newPoints > 0) {
     size_t gridSize = grid.getStorage().getSize();
@@ -246,7 +247,6 @@ void DBMatOfflineChol::choleskyModification(Grid& grid,
   throw algorithm_exception("built withot GSL");
 #endif /*USE_GSL*/
 }
-
 
 void DBMatOfflineChol::choleskyAddPoint(DataVector& newCol, size_t size) {
 #ifdef USE_GSL
@@ -398,5 +398,5 @@ void DBMatOfflineChol::choleskyPermutation(size_t k, size_t l, size_t job) {
 sgpp::datadriven::MatrixDecompositionType DBMatOfflineChol::getDecompositionType() {
   return sgpp::datadriven::MatrixDecompositionType::Chol;
 }
-} /* namespace datadriven */
+}  // namespace datadriven
 } /* namespace sgpp */

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.cpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.cpp
@@ -17,6 +17,10 @@
 namespace sgpp {
 namespace pde {
 
+OperationMatrixLTwoDotExplicitLinear::OperationMatrixLTwoDotExplicitLinear() : ownsMatrix_(false) {
+  m_ = nullptr;
+};
+
 OperationMatrixLTwoDotExplicitLinear::OperationMatrixLTwoDotExplicitLinear(
     sgpp::base::DataMatrix* m, sgpp::base::Grid* grid)
     : ownsMatrix_(false) {
@@ -28,75 +32,6 @@ OperationMatrixLTwoDotExplicitLinear::OperationMatrixLTwoDotExplicitLinear(sgpp:
     : ownsMatrix_(true) {
   m_ = new sgpp::base::DataMatrix(grid->getSize(), grid->getSize());
   buildMatrix(grid);
-}
-
-inline void OperationMatrixLTwoDotExplicitLinear::buildMatrixWithBounds(
-    sgpp::base::DataMatrix* mat, sgpp::base::Grid* grid, size_t i_start, size_t i_end,
-    size_t j_start, size_t j_end) {
-  // todo: dima, bounds einbauen
-  size_t gridSize = grid->getSize();
-  size_t gridDim = grid->getDimension();
-
-  sgpp::base::DataMatrix level(gridSize, gridDim);
-  sgpp::base::DataMatrix index(gridSize, gridDim);
-
-  grid->getStorage().getLevelIndexArraysForEval(level, index);
-
-  // init standard values
-  i_start = i_start == 0 ? 0 : i_start;
-  i_end = i_end == 0 ? gridSize : i_end;
-
-  for (size_t i = i_start; i < i_end; i++) {
-    j_start = j_start == 0 ? i : j_start;
-    j_end = j_end == 0 ? gridSize : j_end;
-#pragma omp parallel for schedule(guided)
-    for (size_t j = j_start; j < j_end; j++) {
-      double res = 1;
-
-      for (size_t k = 0; k < gridDim; k++) {
-        double lik = level.get(i, k);
-        double ljk = level.get(j, k);
-        double iik = index.get(i, k);
-        double ijk = index.get(j, k);
-
-        if (lik == ljk) {
-          if (iik == ijk) {
-            // Use formula for identical ansatz functions:
-            res *= 2 / lik / 3;
-          } else {
-            // Different index, but same level => ansatz functions do not overlap:
-            res = 0.;
-            break;
-          }
-        } else {
-          if (std::max((iik - 1) / lik, (ijk - 1) / ljk) >=
-              std::min((iik + 1) / lik, (ijk + 1) / ljk)) {
-            // Ansatz functions do not not overlap:
-            res = 0.;
-            break;
-          } else {
-            // Use formula for different overlapping ansatz functions:
-            if (lik > ljk) {                            // Phi_i_k is the "smaller" ansatz function
-              double diff = (iik / lik) - (ijk / ljk);  // x_i_k - x_j_k
-              double temp_res = fabs(diff - (1 / lik)) + fabs(diff + (1 / lik)) - fabs(diff);
-              temp_res *= ljk;
-              temp_res = (1 - temp_res) / lik;
-              res *= temp_res;
-            } else {                                    // Phi_j_k is the "smaller" ansatz function
-              double diff = (ijk / ljk) - (iik / lik);  // x_j_k - x_i_k
-              double temp_res = fabs(diff - (1 / ljk)) + fabs(diff + (1 / ljk)) - fabs(diff);
-              temp_res *= lik;
-              temp_res = (1 - temp_res) / ljk;
-              res *= temp_res;
-            }
-          }
-        }
-      }
-
-      mat->set(i, j, res);
-      mat->set(j, i, res);
-    }
-  }
 }
 
 void OperationMatrixLTwoDotExplicitLinear::buildMatrix(sgpp::base::Grid* grid) {

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.cpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.cpp
@@ -19,7 +19,7 @@ namespace pde {
 
 OperationMatrixLTwoDotExplicitLinear::OperationMatrixLTwoDotExplicitLinear() : ownsMatrix_(false) {
   m_ = nullptr;
-};
+}
 
 OperationMatrixLTwoDotExplicitLinear::OperationMatrixLTwoDotExplicitLinear(
     sgpp::base::DataMatrix* m, sgpp::base::Grid* grid)

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
@@ -75,6 +75,9 @@ class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix 
 
     grid->getStorage().getLevelIndexArraysForEval(level, index);
 
+    // needed for non-quadratic matrix cases
+    bool mat_quadratic = (i_start + i_end + j_start + j_end == 0);
+
     // init standard values
     i_end = i_end == 0 ? gridSize : i_end;
 
@@ -124,9 +127,7 @@ class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix 
             }
           }
         }
-
-        // if quadratic, then L2 matrix is symmetric
-        if (i_end - i_start == j_end - j_start) {
+        if (mat_quadratic) {
           mat->set(i, j, res);
           mat->set(j, i, res);
         } else {

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
@@ -6,9 +6,9 @@
 #ifndef OperationMatrixLTwoDotExplicitLinear_HPP_
 #define OperationMatrixLTwoDotExplicitLinear_HPP_
 
-#include <sgpp/base/operation/hash/OperationMatrix.hpp>
 #include <sgpp/base/datatypes/DataMatrix.hpp>
 #include <sgpp/base/grid/Grid.hpp>
+#include <sgpp/base/operation/hash/OperationMatrix.hpp>
 
 #include <sgpp/globaldef.hpp>
 
@@ -48,6 +48,19 @@ class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix 
    * @param result DataVector into which the result of multiplication is stored
    */
   virtual void mult(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result);
+
+  /**
+   * generalization of "buildMatrix" function, creates L2-dot-product matrix for specified bounds
+   * @param mat matrix for storage of L2 producs
+   * @param grid the underlying grid
+   * @param i_start start index for row iteration
+   * @param i_end end index for row iteration
+   * @param j_start start index for column iteration
+   * @param j_end end index for column iteration
+   */
+  void buildMatrixWithBounds(sgpp::base::DataMatrix* mat, sgpp::base::Grid* grid,
+                             size_t i_start = 0, size_t i_end = 0, size_t j_start = 0,
+                             size_t j_end = 0);
 
  private:
   /**

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
@@ -12,6 +12,8 @@
 
 #include <sgpp/globaldef.hpp>
 
+#include <algorithm>
+
 namespace sgpp {
 namespace pde {
 
@@ -135,7 +137,7 @@ class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix 
         }
       }
     }
-  };
+  }
 
  private:
   /**

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitLinear.hpp
@@ -21,13 +21,19 @@ namespace pde {
 class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix {
  public:
   /**
-   * Constructor that uses a external matrix pointer to construct the matrix,
+   * Constructor that only builds the object, without initialization
+   */
+  OperationMatrixLTwoDotExplicitLinear();
+
+  /**
+   * Constructor that uses an external matrix pointer to construct the matrix,
    * i.e. matrix is NOT destroyed by the destructor of OperationMatrixLTwoDotExplicitLinearFullGrid
    *
    * @param m pointer to datamatrix of size (number of grid point) x (number of grid points)
    * @param grid the sparse grid
    */
   OperationMatrixLTwoDotExplicitLinear(sgpp::base::DataMatrix* m, sgpp::base::Grid* grid);
+
   /**
    * Constructor that creates an own matrix
    * i.e. matrix is destroyed by the destructor of OperationMatrixLTwoDotExplicitLinearFullGrid
@@ -58,9 +64,77 @@ class OperationMatrixLTwoDotExplicitLinear : public sgpp::base::OperationMatrix 
    * @param j_start start index for column iteration
    * @param j_end end index for column iteration
    */
-  void buildMatrixWithBounds(sgpp::base::DataMatrix* mat, sgpp::base::Grid* grid,
-                             size_t i_start = 0, size_t i_end = 0, size_t j_start = 0,
-                             size_t j_end = 0);
+  inline void buildMatrixWithBounds(sgpp::base::DataMatrix* mat, sgpp::base::Grid* grid,
+                                    size_t i_start = 0, size_t i_end = 0, size_t j_start = 0,
+                                    size_t j_end = 0) {
+    size_t gridSize = grid->getSize();
+    size_t gridDim = grid->getDimension();
+
+    sgpp::base::DataMatrix level(gridSize, gridDim);
+    sgpp::base::DataMatrix index(gridSize, gridDim);
+
+    grid->getStorage().getLevelIndexArraysForEval(level, index);
+
+    // init standard values
+    i_end = i_end == 0 ? gridSize : i_end;
+
+    for (size_t i = i_start; i < i_end; i++) {
+      j_start = j_start == 0 ? i : j_start;
+      j_end = j_end == 0 ? gridSize : j_end;
+#pragma omp parallel for schedule(guided)
+      for (size_t j = j_start; j < j_end; j++) {
+        double res = 1;
+
+        for (size_t k = 0; k < gridDim; k++) {
+          double lik = level.get(i, k);
+          double ljk = level.get(j, k);
+          double iik = index.get(i, k);
+          double ijk = index.get(j, k);
+
+          if (lik == ljk) {
+            if (iik == ijk) {
+              // Use formula for identical ansatz functions:
+              res *= 2 / lik / 3;
+            } else {
+              // Different index, but same level => ansatz functions do not overlap:
+              res = 0.;
+              break;
+            }
+          } else {
+            if (std::max((iik - 1) / lik, (ijk - 1) / ljk) >=
+                std::min((iik + 1) / lik, (ijk + 1) / ljk)) {
+              // Ansatz functions do not not overlap:
+              res = 0.;
+              break;
+            } else {
+              // Use formula for different overlapping ansatz functions:
+              if (lik > ljk) {  // Phi_i_k is the "smaller" ansatz function
+                double diff = (iik / lik) - (ijk / ljk);  // x_i_k - x_j_k
+                double temp_res = fabs(diff - (1 / lik)) + fabs(diff + (1 / lik)) - fabs(diff);
+                temp_res *= ljk;
+                temp_res = (1 - temp_res) / lik;
+                res *= temp_res;
+              } else {  // Phi_j_k is the "smaller" ansatz function
+                double diff = (ijk / ljk) - (iik / lik);  // x_j_k - x_i_k
+                double temp_res = fabs(diff - (1 / ljk)) + fabs(diff + (1 / ljk)) - fabs(diff);
+                temp_res *= lik;
+                temp_res = (1 - temp_res) / ljk;
+                res *= temp_res;
+              }
+            }
+          }
+        }
+
+        // if quadratic, then L2 matrix is symmetric
+        if (i_end - i_start == j_end - j_start) {
+          mat->set(i, j, res);
+          mat->set(j, i, res);
+        } else {
+          mat->set(i, j - j_start, res);
+        }
+      }
+    }
+  };
 
  private:
   /**

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.cpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.cpp
@@ -17,7 +17,10 @@
 namespace sgpp {
 namespace pde {
 
-OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear(){};
+OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear()
+    : ownsMatrix_(false) {
+  m_ = nullptr;
+}
 
 OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear(
     sgpp::base::DataMatrix* m, sgpp::base::Grid* grid)

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.cpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.cpp
@@ -17,6 +17,8 @@
 namespace sgpp {
 namespace pde {
 
+OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear(){};
+
 OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear(
     sgpp::base::DataMatrix* m, sgpp::base::Grid* grid)
     : ownsMatrix_(false) {
@@ -24,118 +26,15 @@ OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModi
   buildMatrix(grid);
 }
 
-OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear
-    (sgpp::base::Grid* grid)
+OperationMatrixLTwoDotExplicitModifiedLinear::OperationMatrixLTwoDotExplicitModifiedLinear(
+    sgpp::base::Grid* grid)
     : ownsMatrix_(true) {
   m_ = new sgpp::base::DataMatrix(grid->getSize(), grid->getSize());
   buildMatrix(grid);
 }
 
 void OperationMatrixLTwoDotExplicitModifiedLinear::buildMatrix(sgpp::base::Grid* grid) {
-  size_t gridSize = grid->getSize();
-  size_t gridDim = grid->getDimension();
-
-  sgpp::base::DataMatrix level(gridSize, gridDim);
-  sgpp::base::DataMatrix index(gridSize, gridDim);
-
-  grid->getStorage().getLevelIndexArraysForEval(level, index);
-
-  for (size_t i = 0; i < gridSize; i++) {
-// #pragma omp parallel for schedule(guided)
-    for (size_t j = i; j < gridSize; j++) {
-      double res = 1;
-
-      for (size_t k = 0; k < gridDim; k++) {
-        double lik = level.get(i, k);
-        double ljk = level.get(j, k);
-        double iik = index.get(i, k);
-        double ijk = index.get(j, k);
-        if (lik == 2.) {
-          if (ljk == 2.) {
-            // do nothing (multiply with 1)
-          } else if (ljk -1 == static_cast<int>(ijk) || ijk == 1.) {
-            // right or left modified basis
-            res *= 2./ ljk;
-          } else {
-            // regular ansatz function
-            res *= 1./ljk;
-          }
-        } else if (ljk == 2.) {
-          if (lik -1 == iik || iik == 1.) {
-            res *= 2./ lik;
-          } else {
-            res *= 1./lik;
-          }
-        } else if (lik == ljk) {
-          if (iik == ijk) {
-            if (lik -1 == iik || iik == 1.) {
-              // Identical modified basis
-              res *= 16.0/(3.0* lik);
-            } else {
-              // Use formula for identical ansatz functions:
-              res *= 2 / lik / 3;
-            }
-          } else {
-            // Different index, but same level => ansatz functions do not overlap:
-            res = 0.;
-            break;
-          }
-        } else {
-          if (std::max((iik - 1) / lik, (ijk - 1) / ljk) >=
-              std::min((iik + 1) / lik, (ijk + 1) / ljk)) {
-            // Ansatz functions do not not overlap:
-            res = 0.;
-            break;
-          } else {
-            // Use formula for different overlapping ansatz functions:
-            if (lik > ljk) {                            // Phi_i_k is the "smaller" ansatz function
-              if (ljk -1 == static_cast<int>(ijk) || ijk == 1.) {  // "larger" function is modified
-                double ldiff = lik/ljk;
-                // "smaller" function is modified too
-                if (lik -1 == static_cast<int>(iik) || iik == 1.) {
-                  res *= 2/3. * (2+ 2*(2-1./ldiff)) /lik;
-                } else {  // smaller function is a inner function
-                  auto phi = [] (double x) -> double{return 2-2*x;};
-                  double tmpi = (iik > lik/2.) ? lik - iik : iik;
-                  double xi = tmpi*0.5/ldiff;
-                  double delta = 0.25/ldiff;
-                  res *= 4./6. * (phi(xi -delta) + phi(xi) + phi(xi+delta)) /lik;
-                }
-              } else {  // two inner ansatz functions
-                double diff = (iik / lik) - (ijk / ljk);  // x_i_k - x_j_k
-                double temp_res = fabs(diff - (1 / lik)) + fabs(diff + (1 / lik)) - fabs(diff);
-                temp_res *= ljk;
-                temp_res = (1 - temp_res) / lik;
-                res *= temp_res;
-              }
-            } else {                                    // Phi_j_k is the "smaller" ansatz function
-              if (lik -1 == static_cast<int>(iik) || iik == 1.) {  // "larger" function is modified
-                double ldiff = ljk/lik;
-                // "smaller" function is modified too
-                if (ljk -1 == static_cast<int>(ijk) || ijk == 1.) {
-                  res *= 2/3. * (2+ 2*(2-1./ldiff)) /ljk;
-                } else {  // smaller function is a inner function
-                  auto phi = [] (double x) -> double{return 2-2*x;};
-                  double tmpi = (ijk > ljk/2.)? ljk - ijk: ijk;
-                  double xi = tmpi*0.5/ldiff;
-                  double delta = 0.25/ldiff;
-                  res *= 4./6. * (phi(xi -delta) + phi(xi) + phi(xi+delta)) /ljk;
-                }
-              } else {
-                double diff = (ijk / ljk) - (iik / lik);  // x_j_k - x_i_k
-                double temp_res = fabs(diff - (1 / ljk)) + fabs(diff + (1 / ljk)) - fabs(diff);
-                temp_res *= lik;
-                temp_res = (1 - temp_res) / ljk;
-                res *= temp_res;
-              }
-            }
-          }
-        }
-      }
-      m_->set(i, j, res);
-      m_->set(j, i, res);
-    }
-  }
+  this->buildMatrixWithBounds(this->m_, grid);
 }
 
 OperationMatrixLTwoDotExplicitModifiedLinear::~OperationMatrixLTwoDotExplicitModifiedLinear() {
@@ -143,7 +42,7 @@ OperationMatrixLTwoDotExplicitModifiedLinear::~OperationMatrixLTwoDotExplicitMod
 }
 
 void OperationMatrixLTwoDotExplicitModifiedLinear::mult(sgpp::base::DataVector& alpha,
-                                                sgpp::base::DataVector& result) {
+                                                        sgpp::base::DataVector& result) {
   size_t nrows = m_->getNrows();
   size_t ncols = m_->getNcols();
 

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.hpp
@@ -12,6 +12,8 @@
 
 #include <sgpp/globaldef.hpp>
 
+#include <algorithm>
+
 namespace sgpp {
 namespace pde {
 
@@ -185,7 +187,7 @@ class OperationMatrixLTwoDotExplicitModifiedLinear : public sgpp::base::Operatio
         }
       }
     }
-  };
+  }
 
  private:
   /**

--- a/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.hpp
+++ b/pde/src/sgpp/pde/operation/hash/OperationMatrixLTwoDotExplicitModifiedLinear.hpp
@@ -6,9 +6,9 @@
 #ifndef OperationMatrixLTwoDotExplicitModifiedLinear_HPP_
 #define OperationMatrixLTwoDotExplicitModifiedLinear_HPP_
 
-#include <sgpp/base/operation/hash/OperationMatrix.hpp>
 #include <sgpp/base/datatypes/DataMatrix.hpp>
 #include <sgpp/base/grid/Grid.hpp>
+#include <sgpp/base/operation/hash/OperationMatrix.hpp>
 
 #include <sgpp/globaldef.hpp>
 
@@ -21,8 +21,13 @@ namespace pde {
 class OperationMatrixLTwoDotExplicitModifiedLinear : public sgpp::base::OperationMatrix {
  public:
   /**
+   * Constructor that only builds the object, without initialization
+   */
+  OperationMatrixLTwoDotExplicitModifiedLinear();
+  /**
    * Constructor that uses a external matrix pointer to construct the matrix,
-   * i.e. matrix is NOT destroyed by the destructor of OperationMatrixLTwoDotExplicitModifiedLinearFullGrid
+   * i.e. matrix is NOT destroyed by the destructor of
+   * OperationMatrixLTwoDotExplicitModifiedLinearFullGrid
    *
    * @param m pointer to datamatrix of size (number of grid point) x (number of grid points)
    * @param grid the sparse grid
@@ -30,7 +35,8 @@ class OperationMatrixLTwoDotExplicitModifiedLinear : public sgpp::base::Operatio
   OperationMatrixLTwoDotExplicitModifiedLinear(sgpp::base::DataMatrix* m, sgpp::base::Grid* grid);
   /**
    * Constructor that creates an own matrix
-   * i.e. matrix is destroyed by the destructor of OperationMatrixLTwoDotExplicitModifiedLinearFullGrid
+   * i.e. matrix is destroyed by the destructor of
+   * OperationMatrixLTwoDotExplicitModifiedLinearFullGrid
    *
    * @param grid the sparse grid
    */
@@ -48,6 +54,138 @@ class OperationMatrixLTwoDotExplicitModifiedLinear : public sgpp::base::Operatio
    * @param result DataVector into which the result of multiplication is stored
    */
   virtual void mult(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result);
+
+  /**
+   * generalization of "buildMatrix" function, creates L2-dot-product matrix for specified bounds
+   * @param mat matrix for storage of L2 products
+   * @param grid the underlying grid
+   * @param i_start start index for row iteration
+   * @param i_end end index for row iteration
+   * @param j_start start index for column iteration
+   * @param j_end end index for column iteration
+   */
+  inline void buildMatrixWithBounds(sgpp::base::DataMatrix* mat, sgpp::base::Grid* grid,
+                                    size_t i_start = 0, size_t i_end = 0, size_t j_start = 0,
+                                    size_t j_end = 0) {
+    size_t gridSize = grid->getSize();
+    size_t gridDim = grid->getDimension();
+
+    sgpp::base::DataMatrix level(gridSize, gridDim);
+    sgpp::base::DataMatrix index(gridSize, gridDim);
+
+    grid->getStorage().getLevelIndexArraysForEval(level, index);
+
+    // needed for non-quadratic matrix cases
+    bool mat_quadratic = (i_start + i_end + j_start + j_end == 0);
+
+    // init standard values
+    i_end = i_end == 0 ? gridSize : i_end;
+
+    for (size_t i = 0; i < gridSize; i++) {
+      j_start = j_start == 0 ? i : j_start;
+      j_end = j_end == 0 ? gridSize : j_end;
+      // #pragma omp parallel for schedule(guided)
+      for (size_t j = i; j < gridSize; j++) {
+        double res = 1;
+
+        for (size_t k = 0; k < gridDim; k++) {
+          double lik = level.get(i, k);
+          double ljk = level.get(j, k);
+          double iik = index.get(i, k);
+          double ijk = index.get(j, k);
+          if (lik == 2.) {
+            if (ljk == 2.) {
+              // do nothing (multiply with 1)
+            } else if (ljk - 1 == static_cast<int>(ijk) || ijk == 1.) {
+              // right or left modified basis
+              res *= 2. / ljk;
+            } else {
+              // regular ansatz function
+              res *= 1. / ljk;
+            }
+          } else if (ljk == 2.) {
+            if (lik - 1 == iik || iik == 1.) {
+              res *= 2. / lik;
+            } else {
+              res *= 1. / lik;
+            }
+          } else if (lik == ljk) {
+            if (iik == ijk) {
+              if (lik - 1 == iik || iik == 1.) {
+                // Identical modified basis
+                res *= 16.0 / (3.0 * lik);
+              } else {
+                // Use formula for identical ansatz functions:
+                res *= 2 / lik / 3;
+              }
+            } else {
+              // Different index, but same level => ansatz functions do not overlap:
+              res = 0.;
+              break;
+            }
+          } else {
+            if (std::max((iik - 1) / lik, (ijk - 1) / ljk) >=
+                std::min((iik + 1) / lik, (ijk + 1) / ljk)) {
+              // Ansatz functions do not not overlap:
+              res = 0.;
+              break;
+            } else {
+              // Use formula for different overlapping ansatz functions:
+              if (lik > ljk) {  // Phi_i_k is the "smaller" ansatz function
+                if (ljk - 1 == static_cast<int>(ijk) ||
+                    ijk == 1.) {  // "larger" function is modified
+                  double ldiff = lik / ljk;
+                  // "smaller" function is modified too
+                  if (lik - 1 == static_cast<int>(iik) || iik == 1.) {
+                    res *= 2 / 3. * (2 + 2 * (2 - 1. / ldiff)) / lik;
+                  } else {  // smaller function is a inner function
+                    auto phi = [](double x) -> double { return 2 - 2 * x; };
+                    double tmpi = (iik > lik / 2.) ? lik - iik : iik;
+                    double xi = tmpi * 0.5 / ldiff;
+                    double delta = 0.25 / ldiff;
+                    res *= 4. / 6. * (phi(xi - delta) + phi(xi) + phi(xi + delta)) / lik;
+                  }
+                } else {                                    // two inner ansatz functions
+                  double diff = (iik / lik) - (ijk / ljk);  // x_i_k - x_j_k
+                  double temp_res = fabs(diff - (1 / lik)) + fabs(diff + (1 / lik)) - fabs(diff);
+                  temp_res *= ljk;
+                  temp_res = (1 - temp_res) / lik;
+                  res *= temp_res;
+                }
+              } else {  // Phi_j_k is the "smaller" ansatz function
+                if (lik - 1 == static_cast<int>(iik) ||
+                    iik == 1.) {  // "larger" function is modified
+                  double ldiff = ljk / lik;
+                  // "smaller" function is modified too
+                  if (ljk - 1 == static_cast<int>(ijk) || ijk == 1.) {
+                    res *= 2 / 3. * (2 + 2 * (2 - 1. / ldiff)) / ljk;
+                  } else {  // smaller function is a inner function
+                    auto phi = [](double x) -> double { return 2 - 2 * x; };
+                    double tmpi = (ijk > ljk / 2.) ? ljk - ijk : ijk;
+                    double xi = tmpi * 0.5 / ldiff;
+                    double delta = 0.25 / ldiff;
+                    res *= 4. / 6. * (phi(xi - delta) + phi(xi) + phi(xi + delta)) / ljk;
+                  }
+                } else {
+                  double diff = (ijk / ljk) - (iik / lik);  // x_j_k - x_i_k
+                  double temp_res = fabs(diff - (1 / ljk)) + fabs(diff + (1 / ljk)) - fabs(diff);
+                  temp_res *= lik;
+                  temp_res = (1 - temp_res) / ljk;
+                  res *= temp_res;
+                }
+              }
+            }
+          }
+        }
+        if (mat_quadratic) {
+          mat->set(i, j, res);
+          mat->set(j, i, res);
+        } else {
+          mat->set(i, j - j_start, res);
+        }
+      }
+    }
+  };
 
  private:
   /**


### PR DESCRIPTION
Adds support for ModLinear gridType for datadriven OnOff learning.

+ refactores L2 Products in pde, for Linear and ModLinear (optional generalized parameters)
+ adapts OrthoAdapt and Chol cases to automatically handle supported GridTypes when refining

Examples in datadriven/examplesPipeline were tested, and boost tests also didn't return errors.