### PR TITLE
Fix missing _OPENMP guards

### DIFF
--- a/combigrid/src/sgpp/combigrid/operation/multidim/sparsegrid/LTwoScalarProductHashMapNakBsplineBoundaryCombigrid.cpp
+++ b/combigrid/src/sgpp/combigrid/operation/multidim/sparsegrid/LTwoScalarProductHashMapNakBsplineBoundaryCombigrid.cpp
@@ -6,7 +6,10 @@
 #include <sgpp/combigrid/operation/multidim/sparsegrid/LTwoScalarProductHashMapNakBsplineBoundaryCombigrid.hpp>
 #include <sgpp/combigrid/threading/ThreadPool.hpp>
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
+
 #include <algorithm>
 #include <map>
 #include <vector>

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalModMaskStreaming/OperationMultiEvalModMaskStreaming.cpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalModMaskStreaming/OperationMultiEvalModMaskStreaming.cpp
@@ -69,8 +69,12 @@ void OperationMultiEvalModMaskStreaming::getOpenMPPartitionSegment(size_t start,
                                                                    size_t* segmentStart,
                                                                    size_t* segmentEnd,
                                                                    size_t blocksize) {
-  size_t threadCount = omp_get_num_threads();
-  size_t myThreadNum = omp_get_thread_num();
+  size_t threadCount = 1;
+  size_t myThreadNum = 0;
+#ifdef _OPENMP
+  threadCount = omp_get_num_threads();
+  myThreadNum = omp_get_thread_num();
+#endif
   getPartitionSegment(start, end, threadCount, myThreadNum, segmentStart, segmentEnd, blocksize);
 }
 

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalModMaskStreaming/OperationMultiEvalModMaskStreaming.hpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalModMaskStreaming/OperationMultiEvalModMaskStreaming.hpp
@@ -5,7 +5,9 @@
 
 #pragma once
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include <sgpp/base/operation/hash/OperationMultipleEval.hpp>
 #include <sgpp/base/tools/SGppStopwatch.hpp>

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming.cpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming.cpp
@@ -68,8 +68,12 @@ void OperationMultiEvalStreaming::getPartitionSegment(size_t start, size_t end, 
 void OperationMultiEvalStreaming::getOpenMPPartitionSegment(size_t start, size_t end,
                                                             size_t* segmentStart,
                                                             size_t* segmentEnd, size_t blocksize) {
-  size_t threadCount = omp_get_num_threads();
-  size_t myThreadNum = omp_get_thread_num();
+  size_t threadCount = 1;
+  size_t myThreadNum = 0;
+#ifdef _OPENMP
+  threadCount = omp_get_num_threads();
+  myThreadNum = omp_get_thread_num();
+#endif
   getPartitionSegment(start, end, threadCount, myThreadNum, segmentStart, segmentEnd, blocksize);
 }
 

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming.hpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming.hpp
@@ -5,7 +5,9 @@
 
 #pragma once
 
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 #include "sgpp/base/exception/operation_exception.hpp"
 #include "sgpp/base/operation/hash/OperationMultipleEval.hpp"

--- a/optimization/build/pysgpp/optimization.i
+++ b/optimization/build/pysgpp/optimization.i
@@ -4,6 +4,14 @@
 // sgpp.sparsegrids.org
 
 // to disable OpenMP multi-threading within Python
+%{
+#ifndef _OPENMP
+static void omp_set_num_threads(int num_threads)
+{
+}
+#endif
+%}
+
 void omp_set_num_threads(int num_threads);
 %init %{
     omp_set_num_threads(1);

--- a/pysgpp/pysgpp.i
+++ b/pysgpp/pysgpp.i
@@ -46,7 +46,9 @@
 }
 
 %{
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 %}
 
 %{


### PR DESCRIPTION
Allows to build with clang where openmp is not available