### PR TITLE
Deactivated OMP in pde std updown method

### DIFF
--- a/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
+++ b/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
@@ -55,7 +55,7 @@ void StdUpDown::updown(sgpp::base::DataVector& alpha, sgpp::base::DataVector& re
       updown(temp, result, dim - 1);
     }
 
-// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, 
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two,
 //                                                                        result_temp)
     {  // NOLINT(whitespace/braces)
       updown(alpha, temp_two, dim - 1);

--- a/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
+++ b/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
@@ -39,8 +39,8 @@ void StdUpDown::multParallelBuildingBlock(sgpp::base::DataVector& alpha,
 }
 
 void StdUpDown::updown(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result, size_t dim) {
-  size_t curNumAlgoDims = this->numAlgoDims_;
-  size_t curMaxParallelDims = this->maxParallelDims_;
+  // size_t curNumAlgoDims = this->numAlgoDims_;
+  // size_t curMaxParallelDims = this->maxParallelDims_;
 
   // Unidirectional scheme
   if (dim > 0) {
@@ -55,7 +55,7 @@ void StdUpDown::updown(sgpp::base::DataVector& alpha, sgpp::base::DataVector& re
       updown(temp, result, dim - 1);
     }
 
-// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, \
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, 
 //                                                                        result_temp)
     {  // NOLINT(whitespace/braces)
       updown(alpha, temp_two, dim - 1);

--- a/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
+++ b/pde/src/sgpp/pde/algorithm/StdUpDown.cpp
@@ -20,9 +20,9 @@ StdUpDown::~StdUpDown() {}
 void StdUpDown::mult(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result) {
   sgpp::base::DataVector beta(result.getSize());
   result.setAll(0.0);
-#pragma omp parallel
+// #pragma omp parallel
   {
-#pragma omp single nowait
+// #pragma omp single nowait
     { this->updown(alpha, beta, this->numAlgoDims_ - 1); }
   }
   result.add(beta);
@@ -49,33 +49,33 @@ void StdUpDown::updown(sgpp::base::DataVector& alpha, sgpp::base::DataVector& re
     sgpp::base::DataVector result_temp(alpha.getSize());
     sgpp::base::DataVector temp_two(alpha.getSize());
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp, result)
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp, result)
     {
       up(alpha, temp, this->algoDims[dim]);
       updown(temp, result, dim - 1);
     }
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, \
-                                                                        result_temp)
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, \
+//                                                                        result_temp)
     {  // NOLINT(whitespace/braces)
       updown(alpha, temp_two, dim - 1);
       down(temp_two, result_temp, this->algoDims[dim]);
     }
 
-#pragma omp taskwait
+// #pragma omp taskwait
 
     result.add(result_temp);
   } else {
     // Terminates dimension recursion
     sgpp::base::DataVector temp(alpha.getSize());
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, result)
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, result)
     up(alpha, result, this->algoDims[dim]);
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp)
+// #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp)
     down(alpha, temp, this->algoDims[dim]);
 
-#pragma omp taskwait
+// #pragma omp taskwait
 
     result.add(temp);
   }


### PR DESCRIPTION
This PR deactivates the OpenMP in the troublesome std updown method of the pde module.

This is only meant only as a temporary workaround for #152 not as a complete fix, hence I would recommend to not close that issue for now.