### PR TITLE
Correctly link OpenMP with GCC on old Ubuntus

### DIFF
--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -465,7 +465,7 @@ def configureGNUCompiler(config):
   import platform
   linux_dist = platform.dist()
   if linux_dist[0] == "Ubuntu" and linux_dist[1] in ["16.04", "16.10", "17.04", "17.10", "18.04", "18.10"]:
-    p = subprocess.Popen("gcc -v  -fopenmp -xc /dev/null 2>&1 | awk -F'[=:]' '/LIBRARY_PATH/{print $2}'", shell=True, stdout=subprocess.PIPE)
+    p = subprocess.Popen(config.env["CXX"] + " -v  -fopenmp -xc /dev/null 2>&1 | awk -F'[=:]' '/LIBRARY_PATH/{print $2}'", shell=True, stdout=subprocess.PIPE)
     first_libpath, _ = p.communicate()
     first_libpath = first_libpath.rstrip() # remove trailing newline
     if not os.path.exists(first_libpath):

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -469,9 +469,9 @@ def configureGNUCompiler(config):
     first_libpath, _ = p.communicate()
     first_libpath = first_libpath.rstrip() # remove trailing newline
     if not os.path.exists(first_libpath):
-      print("Mitigation for old Ubuntu failed. Did not get libpath. Continuing WITHOUT openmp.")
+      Helper.printWarning("Mitigation for old Ubuntu failed. Did not get libpath. Continuing WITHOUT openmp.")
     else:
-      print("Mitigation for old Ubuntu: Manually adding {} as first libpath.".format(first_libpath))
+      Helper.printInfo("Mitigation for old Ubuntu: Manually adding {} as first libpath.".format(first_libpath))
       config.env.Append(LIBPATH=[first_libpath])
       # Safety first: Manually specity libgomp.so.1 as additional library before -fopenmp
       config.env.Append(LINKFLAGS=["-l:libgomp.so.1", "-fopenmp"])

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -453,9 +453,33 @@ def configureGNUCompiler(config):
   config.env.Append(CPPFLAGS=allWarnings + [
       "-fno-strict-aliasing",
       "-funroll-loops", "-mfpmath=sse"])
-#   if not config.env["USE_HPX"]:
-  config.env.Append(CPPFLAGS=["-fopenmp"])
-  config.env.Append(LINKFLAGS=["-fopenmp"])
+
+  # Mitigation for old Ubuntu (should probably be also applied to Debian?):
+  # Package 'libomp-dev' installs a symlink 'libgomp.so' to 'libomp.so' in /usr/lib/x86_64-linux.
+  # If this path is manually added (-L...), then ld uses this symlink and, thus, links against
+  # the wrong openmp library.
+  # The mitigation is to ask gcc for its LIBRARY_PATH in combination with -fopenmp and manually
+  # add this as the very first LIBPATH.
+  # Note, that this code also disables openmp if the mitigation command did not produce an
+  # adequate path.
+  import platform
+  linux_dist = platform.dist()
+  if linux_dist[0] == "Ubuntu" and linux_dist[1] in ["16.04", "16.10", "17.04", "17.10", "18.04", "18.10"]:
+    p = subprocess.Popen("gcc -v  -fopenmp -xc /dev/null 2>&1 | awk -F'[=:]' '/LIBRARY_PATH/{print $2}'", shell=True, stdout=subprocess.PIPE)
+    first_libpath, _ = p.communicate()
+    first_libpath = first_libpath.rstrip() # remove trailing newline
+    if not os.path.exists(first_libpath):
+      print("Mitigation for old Ubuntu failed. Did not get libpath. Continuing WITHOUT openmp.")
+    else:
+      print("Mitigation for old Ubuntu: Manually adding {} as first libpath.".format(first_libpath))
+      config.env.Append(LIBPATH=[first_libpath])
+      # Safety first: Manually specity libgomp.so.1 as additional library before -fopenmp
+      config.env.Append(LINKFLAGS=["-l:libgomp.so.1", "-fopenmp"])
+      config.env.Append(CPPFLAGS=["-fopenmp"])
+  else:
+    config.env.Append(CPPFLAGS=["-fopenmp"])
+    config.env.Append(LINKFLAGS=["-fopenmp"])
+
 
   #   # limit the number of errors display to something reasonable (useful for templated code)
   #   config.env.Append(CPPFLAGS=["-fmax-errors=5"])


### PR DESCRIPTION
This is a fix mainly for the Ubuntu versions on neon and helium. I will take the liberty and just use my source code comment as PR description :)

Mitigation for old Ubuntu (should probably be also applied to Debian?):
Package 'libomp-dev' installs a symlink 'libgomp.so' to 'libomp.so' in /usr/lib/x86_64-linux. If this path is manually added (-L...), then ld uses this symlink and, thus, links against
the wrong openmp library. The mitigation is to ask gcc for its LIBRARY_PATH in combination with -fopenmp and manually add this as the very first LIBPATH.

Note, that this code also disables openmp if the mitigation command did not produce an
adequate path.

You can verify that the fix works as follows:
Not fixed:
```sh
$ ldd lib/sgpp/libsgppbase.so
[...]
        libomp.so.5 => /usr/lib/x86_64-linux-gnu/libomp.so.5
[...]
```

Fixed:
```sh
$ ldd lib/sgpp/libsgppbase.so
[...]
        libgomp.so.1 => /usr/lib/x86_64-linux-gnu/libgomp.so.1
[...]
```

//Edit: @leiterrl ping
//Edit2: Should resolve #152 