### PR TITLE
Fix some Clang warnings

### DIFF
--- a/base/src/sgpp/base/operation/hash/OperationMultipleEvalInterModLinear.hpp
+++ b/base/src/sgpp/base/operation/hash/OperationMultipleEvalInterModLinear.hpp
@@ -50,7 +50,7 @@ class OperationMultipleEvalInterModLinear : public OperationMultipleEval {
   void multTranspose(DataVector& source, DataVector& result) override;
 
 
-  double getDuration() { return 0.0; }
+  double getDuration() override { return 0.0; }
 
 
  protected:

--- a/base/src/sgpp/base/operation/hash/common/basis/BsplineModifiedClenshawCurtisBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/BsplineModifiedClenshawCurtisBasis.hpp
@@ -180,7 +180,7 @@ class BsplineModifiedClenshawCurtisBasis : public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const { return degree; }
+  inline size_t getDegree() const override { return degree; }
 
   /**
    * @param l     level of basis function

--- a/base/src/sgpp/base/operation/hash/common/basis/FundamentalNakSplineBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/FundamentalNakSplineBasis.hpp
@@ -841,7 +841,7 @@ class FundamentalNakSplineBasis: public Basis<LT, IT> {
   /**
    * @return      fundamental not-a-knot spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return nakBsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasis.hpp
@@ -903,7 +903,7 @@ class NakBsplineBasis: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return bsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasisDeriv1.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasisDeriv1.hpp
@@ -843,7 +843,7 @@ class NakBsplineBasisDeriv1: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return bsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasisDeriv2.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineBasisDeriv2.hpp
@@ -745,7 +745,7 @@ class NakBsplineBasisDeriv2: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return bsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasis.hpp
@@ -265,7 +265,7 @@ class NakBsplineModifiedBasis: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return nakBsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasisDeriv1.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasisDeriv1.hpp
@@ -264,7 +264,7 @@ class NakBsplineModifiedBasisDeriv1: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return nakBsplineBasisDeriv1.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasisDeriv2.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NakBsplineModifiedBasisDeriv2.hpp
@@ -230,7 +230,7 @@ class NakBsplineModifiedBasisDeriv2: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return nakBsplineBasisDeriv2.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/NaturalBsplineBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/NaturalBsplineBasis.hpp
@@ -454,7 +454,7 @@ class NaturalBsplineBasis: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return bsplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasis.hpp
@@ -1185,7 +1185,7 @@ class WeaklyFundamentalNakSplineBasis: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalSplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasisDeriv1.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasisDeriv1.hpp
@@ -1093,7 +1093,7 @@ class WeaklyFundamentalNakSplineBasisDeriv1: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalSplineBasisDeriv1.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasisDeriv2.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineBasisDeriv2.hpp
@@ -975,7 +975,7 @@ class WeaklyFundamentalNakSplineBasisDeriv2: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalSplineBasisDeriv2.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasis.hpp
@@ -365,7 +365,7 @@ class WeaklyFundamentalNakSplineModifiedBasis: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalNakSplineBasis.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasisDeriv1.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasisDeriv1.hpp
@@ -334,7 +334,7 @@ class WeaklyFundamentalNakSplineModifiedBasisDeriv1: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalNakSplineBasisDeriv1.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasisDeriv2.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalNakSplineModifiedBasisDeriv2.hpp
@@ -309,7 +309,7 @@ class WeaklyFundamentalNakSplineModifiedBasisDeriv2: public Basis<LT, IT> {
   /**
    * @return      B-spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return weaklyFundamentalNakSplineBasisDeriv2.getDegree();
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasis.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasis.hpp
@@ -375,7 +375,7 @@ class WeaklyFundamentalSplineBasis: public Basis<LT, IT> {
   /**
    * @return      Spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return degree;
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasisDeriv1.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasisDeriv1.hpp
@@ -353,7 +353,7 @@ class WeaklyFundamentalSplineBasisDeriv1: public Basis<LT, IT> {
   /**
    * @return      Spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return degree;
   }
 

--- a/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasisDeriv2.hpp
+++ b/base/src/sgpp/base/operation/hash/common/basis/WeaklyFundamentalSplineBasisDeriv2.hpp
@@ -317,7 +317,7 @@ class WeaklyFundamentalSplineBasisDeriv2: public Basis<LT, IT> {
   /**
    * @return      Spline degree
    */
-  inline size_t getDegree() const {
+  inline size_t getDegree() const override {
     return degree;
   }
 

--- a/combigrid/src/sgpp/combigrid/operation/multidim/fullgrid/FullGridCallbackEvaluator.hpp
+++ b/combigrid/src/sgpp/combigrid/operation/multidim/fullgrid/FullGridCallbackEvaluator.hpp
@@ -54,7 +54,9 @@ class FullGridCallbackEvaluator : public AbstractFullGridEvaluationStrategy<V> {
    * @param callback This callback is called (with already locked mutex) from inside one of the
    * returned tasks when all tasks for the given level are completed and the level can be added.
    */
-  std::vector<ThreadPool::Task> getLevelTasks(MultiIndex const &level, ThreadPool::Task callback) {
+  std::vector<ThreadPool::Task> getLevelTasks(
+      MultiIndex const &level,
+      ThreadPool::Task callback) override {
     size_t numDimensions = this->pointHierarchies.size();
     MultiIndex multiBounds(numDimensions);
 

--- a/combigrid/src/sgpp/combigrid/operation/onedim/LinearInterpolationEvaluator.hpp
+++ b/combigrid/src/sgpp/combigrid/operation/onedim/LinearInterpolationEvaluator.hpp
@@ -32,8 +32,8 @@ class LinearInterpolationEvaluator : public AbstractLinearEvaluator<FloatScalarV
   virtual ~LinearInterpolationEvaluator();
   LinearInterpolationEvaluator(LinearInterpolationEvaluator const &other);
 
-  virtual std::vector<FloatScalarVector> getBasisValues() { return basisValues; }
-  virtual std::vector<double> getBasisCoefficients() { return basisCoefficients; }
+  std::vector<FloatScalarVector> getBasisValues() override { return basisValues; }
+  std::vector<double> getBasisCoefficients() override { return basisCoefficients; }
 
   void setGridPoints(std::vector<double> const &newXValues) override;
   void setBasisCoefficientsAtGridPoints(std::vector<double> &functionValues) override;

--- a/combigrid/src/sgpp/combigrid/storage/tree/CombigridTreeStorage.hpp
+++ b/combigrid/src/sgpp/combigrid/storage/tree/CombigridTreeStorage.hpp
@@ -53,9 +53,9 @@ class CombigridTreeStorage : public AbstractCombigridStorage {
       MultiFunction p_func = MultiFunction(constantFunction<base::DataVector const &, double>()));
   virtual ~CombigridTreeStorage();
 
-  virtual std::shared_ptr<AbstractMultiStorageIterator<double>> getGuidedIterator(
+  std::shared_ptr<AbstractMultiStorageIterator<double>> getGuidedIterator(
       MultiIndex const &level, MultiIndexIterator &iterator,
-      std::vector<bool> orderingConfiguration);
+      std::vector<bool> orderingConfiguration) override;
 
   std::shared_ptr<TreeStorage<double>> getStorage(const MultiIndex &level);
 
@@ -63,14 +63,14 @@ class CombigridTreeStorage : public AbstractCombigridStorage {
    * Returns the number of entries (all level-index pairs) in the storage, which indicates the
    * number of function evaluations that have been done. Currently, this is an O(n) method.
    */
-  virtual size_t getNumEntries();
+  size_t getNumEntries() override;
 
-  virtual std::string serialize();
-  virtual void deserialize(std::string const &str);
+  std::string serialize() override;
+  void deserialize(std::string const &str) override;
 
-  virtual void set(MultiIndex const &level, MultiIndex const &index, double value);
+  void set(MultiIndex const &level, MultiIndex const &index, double value) override;
   double get(MultiIndex const &level, MultiIndex const &index) override;
-  virtual void setMutex(std::shared_ptr<std::recursive_mutex> mutexPtr);
+  void setMutex(std::shared_ptr<std::recursive_mutex> mutexPtr) override;
 };
 }  // namespace combigrid
 } /* namespace sgpp*/

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatDMSDenseIChol.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatDMSDenseIChol.cpp
@@ -58,7 +58,6 @@ void DBMatDMSDenseIChol::choleskyBackwardSolve(const sgpp::base::DataMatrix& dec
       tmpVec.setAll(0.0);
 #pragma omp for schedule(guided) nowait
       for (auto i = 0u; i < size; i++) {
-#pragma omp simd
         for (auto j = 0u; j < i; j++) {
           tmpVec[j] += decompMatrix.get(i, j) * alpha.get(i);
         }
@@ -85,6 +84,7 @@ void DBMatDMSDenseIChol::choleskyForwardSolve(const sgpp::base::DataMatrix& deco
 #pragma omp for schedule(guided) nowait
       for (auto i = 0u; i < size; i++) {
         auto tmp = 0.0;
+#pragma omp simd
         for (auto j = 0u; j < i; j++) {
           tmp += decompMatrix.get(i, j) * y.get(j);
         }

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatDMSDenseIChol.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatDMSDenseIChol.cpp
@@ -85,7 +85,6 @@ void DBMatDMSDenseIChol::choleskyForwardSolve(const sgpp::base::DataMatrix& deco
 #pragma omp for schedule(guided) nowait
       for (auto i = 0u; i < size; i++) {
         auto tmp = 0.0;
-#pragma omp simd
         for (auto j = 0u; j < i; j++) {
           tmp += decompMatrix.get(i, j) * y.get(j);
         }
@@ -97,7 +96,6 @@ void DBMatDMSDenseIChol::choleskyForwardSolve(const sgpp::base::DataMatrix& deco
 
 void DBMatDMSDenseIChol::updateProxyMatrixLambda(double lambdaUpdate) const {
   auto size = proxyMatrix.getNrows();
-#pragma omp simd
   for (auto i = 0u; i < size; i++) {
     auto value = proxyMatrix.get(i, i) + lambdaUpdate;
     proxyMatrix.set(i, i, value);

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOfflineOrthoAdapt.hpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOfflineOrthoAdapt.hpp
@@ -37,7 +37,7 @@ class DBMatOfflineOrthoAdapt : public DBMatOffline {
    */
   explicit DBMatOfflineOrthoAdapt(const std::string& fileName);
 
-  DBMatOffline* clone();
+  DBMatOffline* clone() override;
 
   bool isRefineable() override;
 
@@ -52,7 +52,7 @@ class DBMatOfflineOrthoAdapt : public DBMatOffline {
    * @param grid the underlying grid
    * @param regularizationConfig configuaration for the regularization employed
    */
-  void buildMatrix(Grid* grid, RegularizationConfiguration& regularizationConfig);
+  void buildMatrix(Grid* grid, RegularizationConfiguration& regularizationConfig) override;
 
   /**
    * Decomposes and inverts the lhsMatrix of the offline object
@@ -63,7 +63,7 @@ class DBMatOfflineOrthoAdapt : public DBMatOffline {
    * @param densityEstimationConfig the density estimation configuration
    */
   void decomposeMatrix(RegularizationConfiguration& regularizationConfig,
-                       DensityEstimationConfiguration& densityEstimationConfig);
+                       DensityEstimationConfiguration& densityEstimationConfig) override;
 
   /**
    * Decomposes the lhsMatrix into lhs = Q * T * Q^t and stores the orthogonal
@@ -94,7 +94,7 @@ class DBMatOfflineOrthoAdapt : public DBMatOffline {
    *
    * @param fileName path where to store the file
    */
-  void store(const std::string& fileName);
+  void store(const std::string& fileName) override;
 
   /**
    * Override to sync Q and Tinv

--- a/datadriven/src/sgpp/datadriven/application/SparseGridDensityEstimator.hpp
+++ b/datadriven/src/sgpp/datadriven/application/SparseGridDensityEstimator.hpp
@@ -119,7 +119,7 @@ class SparseGridDensityEstimator : public datadriven::DensityEstimator {
    *
    * @param samples DataMatrix (nrows = number of samples, ncols = dimensionality)
    */
-  virtual void initialize(base::DataMatrix& samples);
+  void initialize(base::DataMatrix& samples) override;
 
   /**
    * This methods evaluates the sparse grid density at a single point

--- a/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimation.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimation.hpp
@@ -42,7 +42,7 @@ class ModelFittingDensityEstimation : public ModelFittingBaseSingleGrid {
    */
   virtual void fit(DataMatrix& dataset) = 0;
 
-  virtual void fit(Dataset& dataset) = 0;
+  void fit(Dataset& dataset) override = 0;
 
   /**
    * Updates the model based on new data samples (streaming, batch learning). Requires only
@@ -52,11 +52,11 @@ class ModelFittingDensityEstimation : public ModelFittingBaseSingleGrid {
    */
   virtual void update(DataMatrix& samples) = 0;
 
-  virtual void update(Dataset& dataset) = 0;
+  void update(Dataset& dataset) override = 0;
 
-  virtual double evaluate(const DataVector& sample) = 0;
+  double evaluate(const DataVector& sample) override = 0;
 
-  virtual void evaluate(DataMatrix& samples, DataVector& results) = 0;
+  void evaluate(DataMatrix& samples, DataVector& results) override = 0;
 
   /**
    * Performs a refinement given the new grid size and the points to coarsened

--- a/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationCG.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationCG.hpp
@@ -64,7 +64,7 @@ class ModelFittingDensityEstimationCG : public ModelFittingDensityEstimation {
    * density estimation whatsoever)
    * @param dataset the training dataset that is used to fit the model.
    */
-  void fit(DataMatrix& dataset);
+  void fit(DataMatrix& dataset) override;
 
   /**
    * Performs a refinement given the new grid size and the points to coarsened
@@ -72,7 +72,7 @@ class ModelFittingDensityEstimationCG : public ModelFittingDensityEstimation {
    * @param deletedGridPoints a list of indexes for grid points that will be removed
    * @return if the grid was refined (true)
    */
-  bool refine(size_t newNoPoints, std::list<size_t> *deletedGridPoints);
+  bool refine(size_t newNoPoints, std::list<size_t> *deletedGridPoints) override;
 
   void update(Dataset& dataset) override;
 
@@ -82,7 +82,7 @@ class ModelFittingDensityEstimationCG : public ModelFittingDensityEstimation {
    * whatsoever)
    * @param samples the new data samples
    */
-  void update(DataMatrix& samples);
+  void update(DataMatrix& samples) override;
 
   /**
    * Evaluate the fitted density at a single data point - requires a trained grid.

--- a/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationCombi.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationCombi.hpp
@@ -48,7 +48,7 @@ class ModelFittingDensityEstimationCombi : public ModelFittingDensityEstimation 
    * SGDE approach.
    * @param newDataset the training dataset that is used to fit the model.
    */
-  void fit(Dataset& newDataset);
+  void fit(Dataset& newDataset) override;
 
   /**
    * Fit the grids to the given dataset by determining the surpluses of the initial grid by the
@@ -56,9 +56,9 @@ class ModelFittingDensityEstimationCombi : public ModelFittingDensityEstimation 
    * density estimation whatsoever)
    * @param newDataset the training dataset that is used to fit the model.
    */
-  void fit(DataMatrix& newDataset);
+  void fit(DataMatrix& newDataset) override;
 
-  void update(Dataset& dataset);
+  void update(Dataset& dataset) override;
 
   /**
    * Updates the model based on new data samples (streaming, batch learning). Requires only
@@ -66,14 +66,14 @@ class ModelFittingDensityEstimationCombi : public ModelFittingDensityEstimation 
    * whatsoever)
    * @param samples the new data samples
    */
-  void update(DataMatrix& samples);
+  void update(DataMatrix& samples) override;
 
   /**
    * Evaluate the fitted density at a single data point - requires a trained grid.
    * @param sample vector with the coordinates in all dimensions of that sample.
    * @return evaluation of the trained grid.
    */
-  double evaluate(const DataVector& sample);
+  double evaluate(const DataVector& sample) override;
 
   /**
    * Evaluate the fitted density on a set of data points - requires a trained grid.
@@ -82,19 +82,19 @@ class ModelFittingDensityEstimationCombi : public ModelFittingDensityEstimation 
    * @param results vector where each row will contain the evaluation of the respective sample on
    * the current model.
    */
-  void evaluate(DataMatrix& samples, DataVector& results);
+  void evaluate(DataMatrix& samples, DataVector& results) override;
 
   /**
    * Refines the component with the biggest error
    * @return if a component was refined
    */
-  bool refine();
+  bool refine() override;
 
   /**
    * Currently not implemented for this class due to missing strategy for
    * dimensional adaptive refinement. Throws an application_exception.
    */
-  bool refine(size_t newNoPoints, std::list<size_t>* deletedGridPoints);
+  bool refine(size_t newNoPoints, std::list<size_t>* deletedGridPoints) override;
 
   /**
    * Resets the state of the entire model
@@ -124,7 +124,7 @@ class ModelFittingDensityEstimationCombi : public ModelFittingDensityEstimation 
    */
   CombiScheme scheme;
 
-  bool isRefinable();
+  bool isRefinable() override;
 
   /**
    * Creates a density estimation model that fits the model settings.

--- a/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationOnOff.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationOnOff.hpp
@@ -64,7 +64,7 @@ class ModelFittingDensityEstimationOnOff : public ModelFittingDensityEstimation 
    * density estimation whatsoever)
    * @param dataset the training dataset that is used to fit the model.
    */
-  void fit(DataMatrix& dataset);
+  void fit(DataMatrix& dataset) override;
 
   /**
    * Performs a refinement given the new grid size and the points to coarsened
@@ -72,7 +72,7 @@ class ModelFittingDensityEstimationOnOff : public ModelFittingDensityEstimation 
    * @param deletedGridPoints a list of indexes for grid points that will be removed
    * @return if the grid was refined (true)
    */
-  bool refine(size_t newNoPoints, std::list<size_t> *deletedGridPoints);
+  bool refine(size_t newNoPoints, std::list<size_t> *deletedGridPoints) override;
 
   void update(Dataset& dataset) override;
 
@@ -82,7 +82,7 @@ class ModelFittingDensityEstimationOnOff : public ModelFittingDensityEstimation 
    * whatsoever)
    * @param samples the new data samples
    */
-  void update(DataMatrix& samples);
+  void update(DataMatrix& samples) override;
 
   /**
    * Evaluate the fitted density at a single data point - requires a trained grid.

--- a/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationOnOffParallel.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/fitting/ModelFittingDensityEstimationOnOffParallel.hpp
@@ -75,7 +75,7 @@ class ModelFittingDensityEstimationOnOffParallel : public ModelFittingDensityEst
    * This method makes use of parallelization using ScaLAPACK.
    * @param dataset the training dataset that is used to fit the model.
    */
-  void fit(DataMatrix& dataset);
+  void fit(DataMatrix& dataset) override;
 
   /**
    * Performs a refinement given the new grid size and the points to coarsened.
@@ -83,7 +83,7 @@ class ModelFittingDensityEstimationOnOffParallel : public ModelFittingDensityEst
    * @param deletedGridPoints a list of indexes for grid points that will be removed
    * @return if the grid was refined (always returns true)
    */
-  bool refine(size_t newNoPoints, std::list<size_t>* deletedGridPoints);
+  bool refine(size_t newNoPoints, std::list<size_t>* deletedGridPoints) override;
 
   /**
    * Update the density estimation with new data.
@@ -98,7 +98,7 @@ class ModelFittingDensityEstimationOnOffParallel : public ModelFittingDensityEst
    * This method makes use of parallelization using ScaLAPACK.
    * @param samples the new data samples
    */
-  void update(DataMatrix& samples);
+  void update(DataMatrix& samples) override;
 
   /**
    * Evaluate the fitted density at a single data point - requires a trained grid.

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultipleEvalScalapack/OperationMultipleEvalDistributed.hpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultipleEvalScalapack/OperationMultipleEvalDistributed.hpp
@@ -76,14 +76,14 @@ class OperationMultipleEvalDistributed : public sgpp::base::OperationMultipleEva
   /**
    * Not implemented in distributed version.
    */
-  virtual void mult(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result) {
+  void mult(sgpp::base::DataVector& alpha, sgpp::base::DataVector& result) override {
     throw sgpp::base::not_implemented_exception("only distributed version of mult implemented");
   }
 
   /**
    * Not implemented in distributed version.
    */
-  virtual void multTranspose(sgpp::base::DataVector& source, sgpp::base::DataVector& result) {
+  void multTranspose(sgpp::base::DataVector& source, sgpp::base::DataVector& result) override {
     throw sgpp::base::not_implemented_exception("only distributed version of mult implemented");
   }
 };

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultipleEvalScalapack/OperationMultipleEvalModLinearDistributed.hpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultipleEvalScalapack/OperationMultipleEvalModLinearDistributed.hpp
@@ -48,7 +48,7 @@ class OperationMultipleEvalModLinearDistributed : public OperationMultipleEvalDi
    * @param alpha vector, to which @f$B@f$ is applied. Typically the coefficient vector
    * @param result the result vector of the matrix vector multiplication
    */
-  void multDistributed(sgpp::base::DataVector& alpha, DataVectorDistributed& result);
+  void multDistributed(sgpp::base::DataVector& alpha, DataVectorDistributed& result) override;
 
   /**
    * Distributed version of multTransposed.
@@ -57,7 +57,8 @@ class OperationMultipleEvalModLinearDistributed : public OperationMultipleEvalDi
    * @param source vector, to which @f$B^T@f$ is applied. Typically the coefficient vector
    * @param result the result vector of the matrix vector multiplication
    */
-  void multTransposeDistributed(sgpp::base::DataVector& source, DataVectorDistributed& result);
+  void multTransposeDistributed(
+      sgpp::base::DataVector& source, DataVectorDistributed& result) override;
 
   double getDuration() override;
 

--- a/optimization/src/sgpp/optimization/fuzzy/FuzzyInterval.cpp
+++ b/optimization/src/sgpp/optimization/fuzzy/FuzzyInterval.cpp
@@ -21,7 +21,9 @@ FuzzyInterval::FuzzyInterval(
 }
 
 FuzzyInterval::FuzzyInterval(const FuzzyInterval& other) :
-    FuzzyInterval(supportLowerBound, supportUpperBound, numberOfIntegralSamples) {
+    FuzzyInterval(other.supportLowerBound,
+                  other.supportUpperBound,
+                  other.numberOfIntegralSamples) {
 }
 
 FuzzyInterval::~FuzzyInterval() {

--- a/optimization/src/sgpp/optimization/fuzzy/FuzzyIntervalViaConfidenceInterval.cpp
+++ b/optimization/src/sgpp/optimization/fuzzy/FuzzyIntervalViaConfidenceInterval.cpp
@@ -20,7 +20,8 @@ FuzzyIntervalViaConfidenceInterval::FuzzyIntervalViaConfidenceInterval(
 FuzzyIntervalViaConfidenceInterval::FuzzyIntervalViaConfidenceInterval(
     const FuzzyIntervalViaConfidenceInterval& other) :
         FuzzyIntervalViaConfidenceInterval(
-            supportLowerBound, supportUpperBound, numberOfIntegralSamples, binarySearchTolerance) {
+            other.supportLowerBound, other.supportUpperBound,
+            other.numberOfIntegralSamples, other.binarySearchTolerance) {
 }
 
 FuzzyIntervalViaConfidenceInterval::~FuzzyIntervalViaConfidenceInterval() {

--- a/optimization/src/sgpp/optimization/fuzzy/FuzzyIntervalViaMembershipFunction.cpp
+++ b/optimization/src/sgpp/optimization/fuzzy/FuzzyIntervalViaMembershipFunction.cpp
@@ -23,8 +23,9 @@ FuzzyIntervalViaMembershipFunction::FuzzyIntervalViaMembershipFunction(
 FuzzyIntervalViaMembershipFunction::FuzzyIntervalViaMembershipFunction(
     const FuzzyIntervalViaMembershipFunction& other) :
         FuzzyIntervalViaMembershipFunction(
-            supportLowerBound, supportUpperBound, coreLowerBound, coreUpperBound,
-            numberOfIntegralSamples, binarySearchTolerance) {
+            other.supportLowerBound, other.supportUpperBound,
+            other.coreLowerBound, other.coreUpperBound,
+            other.numberOfIntegralSamples, other.binarySearchTolerance) {
 }
 
 FuzzyIntervalViaMembershipFunction::~FuzzyIntervalViaMembershipFunction() {

--- a/optimization/src/sgpp/optimization/optimizer/constrained/ConstrainedOptimizer.hpp
+++ b/optimization/src/sgpp/optimization/optimizer/constrained/ConstrainedOptimizer.hpp
@@ -129,9 +129,9 @@ class ConstrainedOptimizer : public UnconstrainedOptimizer {
    * @param other optimizer to be copied
    */
   ConstrainedOptimizer(const ConstrainedOptimizer& other)
-      : ConstrainedOptimizer(*unconstrainedOptimizer,
+      : ConstrainedOptimizer(*other.unconstrainedOptimizer,
                              *other.g, other.gGradient.get(),
-                             *other.h, other.hGradient.get(), N) {
+                             *other.h, other.hGradient.get(), other.N) {
   }
 
   /**


### PR DESCRIPTION
This fixes all Clang warnings that pop up on our machines with Clang 3.8 and no additional warning switches.

All future PRs beginning with this one will be automatically compiled with Clang and must not introduce new warnings.

We should think about activating additional Clang warning switches to detect more bugs, see #11.

Fixes #163.