### PR TITLE
Replace 10eXX by 1eXX+1 everywhere

### DIFF
--- a/datadriven/examples/generalisedGridsTest.py
+++ b/datadriven/examples/generalisedGridsTest.py
@@ -50,8 +50,8 @@ def evaluate(X_tr, y_tr, X_te, y_te, T):
 
     solv = sg.SLESolverConfiguration()
     solv.maxIterations_ = 50
-    solv.eps_ = 10e-6
-    solv.threshold_ = 10e-6
+    solv.eps_ = 1e-5
+    solv.threshold_ = 1e-5
     solv.type_ = sg.SLESolverType_CG
 
     final_solv = solv
@@ -60,7 +60,7 @@ def evaluate(X_tr, y_tr, X_te, y_te, T):
     regular = sg.RegularizationConfiguration()
     regular.type_ = sg.RegularizationType_Identity
     regular.exponentBase_ = 1.0
-    regular.lambda_ = 10e-4    
+    regular.lambda_ = 1e-3
 
     ## Create the estimator, train it with the training data and then return the error
     ## for the testing set.

--- a/datadriven/examplesPipeline/ExampleManualPipeline.cpp
+++ b/datadriven/examplesPipeline/ExampleManualPipeline.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
   gridConfig.type_ = GridType::ModLinear;
   gridConfig.dim_ = dataSource->getNextSamples()->getDimension();
   auto& regularizationConfig = config.getRegularizationConfig();
-  regularizationConfig.lambda_ = 10e-1;
+  regularizationConfig.lambda_ = 1e0;
 
   /**
    * Based on our configuration, we then can create a fitter object.

--- a/datadriven/examplesPipeline/config_basicClassification.json
+++ b/datadriven/examplesPipeline/config_basicClassification.json
@@ -29,7 +29,7 @@
             "errorConvergenceThreshold": 0.001
         },
         "regularizationConfig": {
-            "lambda": 10e-2
+            "lambda": 1e-1
         },
         "densityEstimationConfig": {
             "densityEstimationType": "decomposition",

--- a/datadriven/examplesPipeline/config_basicDensityEstimation.json
+++ b/datadriven/examplesPipeline/config_basicDensityEstimation.json
@@ -26,7 +26,7 @@
             "refinementPeriod": 2
         },
         "regularizationConfig": {
-            "lambda": 10e-3
+            "lambda": 1e-2
         },
         "densityEstimationConfig": {
             "densityEstimationType": "decomposition",

--- a/datadriven/examplesPipeline/config_basicRegression.json
+++ b/datadriven/examplesPipeline/config_basicRegression.json
@@ -26,23 +26,23 @@
         "crossValidation": {
             "enable": true,
             "kFold": 2,
-            "lambda": 10e-4,
-            "lambdaStart": 10e-5,
-            "lambdaEnd": 10e-3,
-            "lambdaSteps": 10e-4
+            "lambda": 1e-3,
+            "lambdaStart": 1e-4,
+            "lambdaEnd": 1e-2,
+            "lambdaSteps": 1e-3
         },
         "solverRefineConfig": {
-            "eps": 10e-15,
+            "eps": 1e-14,
             "maxIterations": 100,
             "threshold": 1
         },
         "solverFinalConfig": {
-            "eps": 10e-15,
+            "eps": 1e-14,
             "maxIterations": 100,
             "threshold": 1
         },
         "regularizationConfig": {
-            "lambda": 10e-7
+            "lambda": 1e-6
         }
     }
 }

--- a/datadriven/examplesPipeline/config_databaseExample.json
+++ b/datadriven/examplesPipeline/config_databaseExample.json
@@ -21,7 +21,7 @@
             "errorBasedRefinement": false
         },
         "regularizationConfig": {
-            "lambda": 10e-3
+            "lambda": 1e-2
         },
         "densityEstimationConfig": {
             "densityEstimationType": "decomposition",

--- a/datadriven/examplesPipeline/config_geometryAwareClassification.json
+++ b/datadriven/examplesPipeline/config_geometryAwareClassification.json
@@ -15,7 +15,7 @@
             "threshold": "0.001"
         },
         "regularizationConfig":{
-            "lambda": "10e-2"
+            "lambda": "1e-1"
         },
         "densityEstimationConfig":{
             "densityEstimationType": "decomposition",

--- a/datadriven/src/sgpp/datadriven/datamining/modules/hpo/bo/BayesianOptimization.cpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/hpo/bo/BayesianOptimization.cpp
@@ -235,7 +235,7 @@ void BayesianOptimization::decomposeCholesky(base::DataMatrix &km, base::DataMat
         gnew.set(i, i, value);
       } else {
         decomFailed = true;
-        gnew.set(i, i, 10e-8);
+        gnew.set(i, i, 1e-7);
       }
     }
   }

--- a/datadriven/tests/DataMiningConfigParserTest.cpp
+++ b/datadriven/tests/DataMiningConfigParserTest.cpp
@@ -182,7 +182,7 @@ BOOST_AUTO_TEST_CASE(testFitterSolverRefineConfig) {
 
   SLESolverConfiguration defaults;
   defaults.type_ = SLESolverType::BiCGSTAB;
-  defaults.eps_ = 10e-5;
+  defaults.eps_ = 1e-4;
   defaults.maxIterations_ = 42;
   defaults.threshold_ = 1;
   SLESolverConfiguration config;
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(testFitterSolverRefineConfig) {
 
   BOOST_CHECK_EQUAL(hasConfig, true);
   BOOST_CHECK_EQUAL(static_cast<int>(config.type_), static_cast<int>(SLESolverType::CG));
-  BOOST_CHECK_CLOSE(config.eps_, 10e-15, tolerance);
+  BOOST_CHECK_CLOSE(config.eps_, 1e-14, tolerance);
   BOOST_CHECK_EQUAL(config.maxIterations_, 100);
   BOOST_CHECK_EQUAL(config.threshold_, 1);
 }
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(testFitterSolverFinalConfig) {
 
   SLESolverConfiguration defaults;
   defaults.type_ = SLESolverType::BiCGSTAB;
-  defaults.eps_ = 10e-5;
+  defaults.eps_ = 1e-4;
   defaults.maxIterations_ = 42;
   defaults.threshold_ = 1;
   SLESolverConfiguration config;
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(testFitterSolverFinalConfig) {
 
   BOOST_CHECK_EQUAL(hasConfig, true);
   BOOST_CHECK_EQUAL(static_cast<int>(config.type_), static_cast<int>(SLESolverType::CG));
-  BOOST_CHECK_CLOSE(config.eps_, 10e-15, tolerance);
+  BOOST_CHECK_CLOSE(config.eps_, 1e-14, tolerance);
   BOOST_CHECK_EQUAL(config.maxIterations_, 100);
   BOOST_CHECK_EQUAL(config.threshold_, 1);
 }
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(testFitterRegularizationConfig) {
 
   BOOST_CHECK_EQUAL(hasConfig, true);
   BOOST_CHECK_EQUAL(static_cast<int>(config.type_), static_cast<int>(RegularizationType::Identity));
-  BOOST_CHECK_CLOSE(config.lambda_, 10e-7, tolerance);
+  BOOST_CHECK_CLOSE(config.lambda_, 1e-6, tolerance);
   BOOST_CHECK_CLOSE(config.exponentBase_, 3.0, tolerance);
   BOOST_CHECK_CLOSE(config.l1Ratio_, 4.0, tolerance);
 }

--- a/datadriven/tests/HPOTest.cpp
+++ b/datadriven/tests/HPOTest.cpp
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(DistanceCalculation) {
       contpoint[k] = curconf.getCont(k);
     }
     double twostepdist = oldconf.getTotalDistance(contpoint, scales);
-    BOOST_CHECK_CLOSE(curdist, twostepdist, 10e-6);
+    BOOST_CHECK_CLOSE(curdist, twostepdist, 1e-5);
     oldconf = curconf;
   }
 }
@@ -312,8 +312,8 @@ BOOST_AUTO_TEST_CASE(addSamplesGP) {
 
   for (size_t i = 0; i < initialConfigs.size(); i++) {
     kernelmatrix.getColumn(i, kernelrow);
-    BOOST_CHECK_CLOSE(bo.mean(kernelrow), dscores[i], 10e-6);
-    BOOST_CHECK_CLOSE(bo.var(kernelrow, 1), 0, 10e-6);
+    BOOST_CHECK_CLOSE(bo.mean(kernelrow), dscores[i], 1e-5);
+    BOOST_CHECK_CLOSE(bo.var(kernelrow, 1), 0, 1e-5);
     // std::cout << "Mean " << i << ": " << bo.mean(kernelrow) << "  |  Original: "
     // << dscores[i] << " | Var: " << bo.var(kernelrow, 1) <<std::endl;
   }
@@ -346,8 +346,8 @@ BOOST_AUTO_TEST_CASE(addSamplesGP) {
 
   for (size_t i = 0; i < initialConfigs.size(); i++) {
     kernelmatrix.getColumn(i, kernelrow);
-    BOOST_CHECK_CLOSE(bo.mean(kernelrow), dscores[i], 10e-6);
-    BOOST_CHECK_CLOSE(bo.var(kernelrow, 1), 0, 10e-6);
+    BOOST_CHECK_CLOSE(bo.mean(kernelrow), dscores[i], 1e-5);
+    BOOST_CHECK_CLOSE(bo.var(kernelrow, 1), 0, 1e-5);
     // std::cout << "Mean " << i << ": " << bo.mean(kernelrow) << "  |  Original: "
     // << dscores[i] << " | Var: " << bo.var(kernelrow, 1) <<std::endl;
   }

--- a/datadriven/tests/dBMatOffline_test.cpp
+++ b/datadriven/tests/dBMatOffline_test.cpp
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteOrthoAdapt) {
   BOOST_CHECK_EQUAL(oldMatrix.getSize(), newMatrix.getSize());
 
   for (size_t i = 0; i < newMatrix.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 1e-4);
   }
 
 
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteOrthoAdapt) {
   BOOST_CHECK_EQUAL(oldMatrixQ.getSize(), newMatrixQ.getSize());
 
   for (size_t i = 0; i < newMatrixQ.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrixQ[i], oldMatrixQ[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrixQ[i], oldMatrixQ[i], 1e-4);
   }
 
   // t_tridiag_inv
@@ -108,7 +108,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteOrthoAdapt) {
   BOOST_CHECK_EQUAL(oldMatrixTinv.getSize(), newMatrixTinv.getSize());
 
   for (size_t i = 0; i < newMatrixTinv.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrixTinv[i], oldMatrixTinv[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrixTinv[i], oldMatrixTinv[i], 1e-4);
   }
 }
 
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteCholesky) {
   BOOST_CHECK_EQUAL(oldMatrix.getSize(), newMatrix.getSize());
 
   for (size_t i = 0; i < newMatrix.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 1e-4);
   }
 }
 
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteEigen) {
   BOOST_CHECK_EQUAL(oldMatrix.getSize(), newMatrix.getSize());
 
   for (size_t i = 0; i < newMatrix.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 1e-4);
   }
 }
 
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(testReadWriteLU) {
   BOOST_CHECK_EQUAL(oldMatrix.getSize(), newMatrix.getSize());
 
   for (size_t i = 0; i < newMatrix.getSize(); i++) {
-    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 10e-5);
+    BOOST_CHECK_CLOSE(newMatrix[i], oldMatrix[i], 1e-4);
   }
 }
 

--- a/datadriven/tests/datadriven/scalapack/test_DataMatrixDistributed.cpp
+++ b/datadriven/tests/datadriven/scalapack/test_DataMatrixDistributed.cpp
@@ -417,7 +417,7 @@ BOOST_AUTO_TEST_CASE(testToVector) {
 
   if (localGrid->isProcessInGrid()) {
     for (size_t i = 0; i < testData.size(); i++) {
-      BOOST_CHECK_CLOSE(vector.get(i), testData[i], 10e-5);
+      BOOST_CHECK_CLOSE(vector.get(i), testData[i], 1e-4);
     }
   }
 }

--- a/datadriven/tests/dataminingConfig.json
+++ b/datadriven/tests/dataminingConfig.json
@@ -55,19 +55,19 @@
 		},
 		"solverRefineConfig": {
 			"solverType": "CG",
-			"eps": 10e-15,
+			"eps": 1e-14,
 			"maxIterations": 100,
 			"threshold": 1
 		},
 		"solverFinalConfig": {
 			"solverType": "CG",
-			"eps": 10e-15,
+			"eps": 1e-14,
 			"maxIterations": 100,
 			"threshold": 1
 		},
 		"regularizationConfig": {
 			"regularizationType": "Identity",
-			"lambda": 10e-7,
+			"lambda": 1e-6,
 			"exponentBase": 3.0,
 			"l1Ratio": 4.0
 		},

--- a/datadriven/tests/denseIChol_test.cpp
+++ b/datadriven/tests/denseIChol_test.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(decomp_identity) {
 
   // test
   for (auto i = 0u; i < A.getSize(); i++) {
-    BOOST_CHECK_CLOSE(A[i], B[i], 10e-5);
+    BOOST_CHECK_CLOSE(A[i], B[i], 1e-4);
   }
 }
 
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE(decomp_diag) {
 
   // test
   for (auto i = 0u; i < A.getSize(); i++) {
-    BOOST_CHECK_CLOSE(A[i], results[i], 10e-5);
+    BOOST_CHECK_CLOSE(A[i], results[i], 1e-4);
   }
 }
 
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(decomp_arbitrary) {
 
   // test
   for (auto i = 0u; i < A.getSize(); i++) {
-    BOOST_CHECK_CLOSE(A[i], results[i], 10e-5);
+    BOOST_CHECK_CLOSE(A[i], results[i], 1e-4);
   }
   omp_set_num_threads(numThreads);
 }

--- a/datadriven/tests/tbin/tcontroller/testsettings.job
+++ b/datadriven/tests/tbin/tcontroller/testsettings.job
@@ -70,8 +70,8 @@ imax = 400
 
 # Maximal accuracy.
 # If the norm of the residuum falls below this threshold, stop the CG iterations
-# default: 10e-20
-# max_threshold = 10e-20
+# default: 1e-19
+# max_threshold = 1e-19
 
 
 

--- a/datadriven/tests/test_Rosenblatt_in_Pipeline.json
+++ b/datadriven/tests/test_Rosenblatt_in_Pipeline.json
@@ -11,7 +11,7 @@
 			"rosenblattConfig": {
 				"numSamples": 100,
 				"gridLevel": 2,
-				"lambda": 10e-5,
+				"lambda": 1e-4,
 				"solverMaxIterations": 1000
 			}
 		}
@@ -50,19 +50,19 @@
 		},
 		"solverRefineConfig": {
 			"solverType": "CG",
-			"eps": 10e-15,
+			"eps": 1e-14,
 			"maxIterations": 100,
 			"threshold": 1
 		},
 		"solverFinalConfig": {
 			"solverType": "CG",
-			"eps": 10e-15,
+			"eps": 1e-14,
 			"maxIterations": 100,
 			"threshold": 1
 		},
 		"regularizationConfig": {
 			"regularizationType": "Identity",
-			"lambda": 10e-7,
+			"lambda": 1e-6,
 			"exponentBase":0.0,
 			"l1Ratio":0.0
 		}

--- a/misc/python/utils/data_projections.py
+++ b/misc/python/utils/data_projections.py
@@ -22,8 +22,8 @@ def getminmax(filename, separator=None):
     """Computes min and max for each parameter"""
     fd = tools.gzOpen(filename, 'r')
 
-    mmax = [-10e10 for d in range(dim)]
-    mmin = [10e10 for d in range(dim)]
+    mmax = [-1e11 for d in range(dim)]
+    mmin = [1e11 for d in range(dim)]
     for line in fd.readlines():
         if "@" in line or len(line)==0:
             continue

--- a/solver/examples/fistaExample.cpp
+++ b/solver/examples/fistaExample.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     /**
     * Here we solve the penalised linear system.
     */
-        solver.solve(*op, weights, y, 500, 10e-5);
+        solver.solve(*op, weights, y, 500, 1e-4);
         std::cout << "Finished solving." << std::endl;
         auto prediction = DataVector(num_examples);
     /**

--- a/solver/tests/test_Fista.cpp
+++ b/solver/tests/test_Fista.cpp
@@ -25,7 +25,7 @@ using sgpp::base::DataMatrix;
 
 BOOST_AUTO_TEST_SUITE(TestFista)
 
-const double eps = 10e-4;
+const double eps = 1e-3;
 
 BOOST_AUTO_TEST_CASE(testFista) {
   const size_t dim = 2;
@@ -46,9 +46,9 @@ BOOST_AUTO_TEST_CASE(testFista) {
   auto grid = sgpp::base::Grid::createModLinearGrid(dim);
   grid->getGenerator().regular(level);
 
-  double lambda = 10e-4;
+  double lambda = 1e-3;
   const size_t maxIt = 2000;
-  const double treshold = 10e-10;
+  const double treshold = 1e-9;
 
   auto ridge = sgpp::solver::RidgeFunction(lambda);
   auto solver = sgpp::solver::Fista<decltype(ridge)>(ridge);

--- a/solver/tests/test_RegularizationFunction.cpp
+++ b/solver/tests/test_RegularizationFunction.cpp
@@ -20,7 +20,7 @@ using sgpp::solver::RidgeFunction;
 
 BOOST_AUTO_TEST_SUITE(TestRegularizationFunction)
 
-const double eps = 10e-6;
+const double eps = 1e-5;
 const double stepsize = 1.0;
 const double lambda = 1.0;
 const auto testVec = DataVector(5, -2.0);


### PR DESCRIPTION
`10e-5` is not 10^-5, but 10^-4. Using this kind of notation is not wrong, but it's pretty confusing. Replace all occurrences of 10eXX with 1eXX+1.