### PR TITLE
Increase necessary SWIG version to 3.0.4

### DIFF
--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -300,8 +300,8 @@ def checkSWIG(config):
         r"[0-9.]*[0-9]+", getOutput(["swig", "-version"]))[0]
 
     swigVersionTuple = config.env._get_major_minor_revision(swigVersion)
-    if swigVersionTuple < (3, 0, 3):
-      Helper.printErrorAndExit("SWIG version too old! At least 3.0.3 required.")
+    if swigVersionTuple < (3, 0, 4):
+      Helper.printErrorAndExit("SWIG version too old! At least 3.0.4 required.")
 
     Helper.printInfo("Using SWIG {}".format(swigVersion))
 


### PR DESCRIPTION
There is a regression in SWIG 3.0.3 that generates invalid Python wrapper code (invalid or missing arguments), see the [SWIG changelog](http://www.swig.org/Release/CHANGES) (scroll to 3.0.4); the relevant bugs are https://github.com/swig/swig/pull/294 and https://github.com/swig/swig/issues/296. For instance the default value for `max_threshold` is missing here, despite being after the keyword argument `verbose`:
```python
class ConjugateGradients(SLESolver):
[...]
    def solve(self, SystemMatrix: 'OperationMatrix', alpha: 'DataVector', b: 'DataVector', reuse: 'bool'=False, verbose: 'bool'=False, max_threshold: 'double') -> "void":
        return _pysgpp_swig.ConjugateGradients_solve(self, SystemMatrix, alpha, b, reuse, verbose, max_threshold)
```
Upgrade the necessary SWIG version to 3.0.4 to fix this (it's fixed there, I tested it).