### PR TITLE
Fixed method name

### DIFF
--- a/datadriven/examplesOCL/multiEvalPerformance.cpp
+++ b/datadriven/examplesOCL/multiEvalPerformance.cpp
@@ -17,7 +17,7 @@ int main(int argc, char** argv) {
   std::string fileName = "debugging.arff";
 
   sgpp::datadriven::ARFFTools arffTools;
-  sgpp::datadriven::Dataset dataset = arffTools.readARFFFromeFile(fileName);
+  sgpp::datadriven::Dataset dataset = arffTools.readARFFFromFile(fileName);
 
   // sgpp::base::DataVector *classes = dataset.getClasses();
   sgpp::base::DataMatrix& trainingData = dataset.getData();


### PR DESCRIPTION
This PR fixes a method name in one of the OCL examples, thus fixing the build with USE_OCL=1.