### PR TITLE
remove hardcoded "sgpp/" folder from library install path

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -286,7 +286,7 @@ Parameters are:
            for line in vars.GenerateHelpText(env).splitlines()]))
 
 # add trailing slashes were required and if not present
-BUILD_DIR = Dir(os.path.join("lib", "sgpp"))
+BUILD_DIR = Dir(os.path.join("lib"))
 Export("BUILD_DIR")
 PYSGPP_PACKAGE_PATH = Dir(os.path.join("lib"))
 Export("PYSGPP_PACKAGE_PATH")
@@ -314,7 +314,7 @@ if env["PLATFORM"] == "win32":
 else:
   Helper.setSpawn(env)
 
-# add #/lib/sgpp to LIBPATH
+# add #/lib to LIBPATH
 # (to add corresponding -L... flags to linker calls)
 env.Append(LIBPATH=[BUILD_DIR])
 
@@ -503,7 +503,7 @@ if env["SG_PYTHON"]:
 if env["SG_JAVA"]:
   env.SConscript("#/jsgpp/SConscript", {"env": env, "moduleName": "jsgpp"})
 
-# compile jsgpp
+# compile matsgpp
 if env["SG_MATLAB"]:
   env.SConscript("#/matsgpp/SConscript", {"env": env, "moduleName": "matsgpp"})
 
@@ -579,7 +579,7 @@ if env["RUN_PYTHON_EXAMPLES"]:
 #########################################################################
 
 installLibSGpp = env.Alias("install-lib-sgpp",
-                           env.Install(os.path.join(env.get("LIBDIR"), "sgpp"),
+                           env.Install(os.path.join(env.get("LIBDIR")),
                                        libraryTargetList))
 
 headerFinalDestList = []

--- a/tools/create_release/deb_package/create_deb.py
+++ b/tools/create_release/deb_package/create_deb.py
@@ -23,8 +23,8 @@ print("Welcome to the SG++ deb-package creation utility")
 print("(please run this utility from the \"deb_pkg\" folder)")
 
 # make sure that SG++ was actually built
-if not os.path.exists("../../../lib/sgpp/libsgppbase.so"):
-    print("Aborting: At least \"libsgppbase.so\" has to exist in \"../../../lib/sgpp\"")
+if not os.path.exists("../../../lib/libsgppbase.so"):
+    print("Aborting: At least \"libsgppbase.so\" has to exist in \"../../../lib\"")
     sys.exit(1)
 
 # make sure that SG++ was built with python spport
@@ -34,7 +34,7 @@ if not os.path.exists("../../../lib/pysgpp/_pysgpp_swig.so"):
 
 # figure out which modules were built
 modules = []
-for so_file in os.listdir("../../../lib/sgpp/"):
+for so_file in os.listdir("../../../lib/"):
     if not so_file.endswith(".so"):
         continue
     modules.append(re.search(r"libsgpp(.*?)\.so", so_file).group(1))
@@ -127,7 +127,7 @@ os.makedirs(package_name + "/usr/lib")
 os.makedirs(package_name + "/usr/include")
 # copy library files
 for module in modules:
-    shutil.copy("../../../lib/sgpp/libsgpp" + module +".so", package_name + "/usr/lib")
+    shutil.copy("../../../lib/libsgpp" + module +".so", package_name + "/usr/lib")
 # copy C++-headers
 for module in modules:
     copy_headers.copy_headers(module, package_name)

--- a/tools/travis_scripts/create_and_patch_python_wheel.sh
+++ b/tools/travis_scripts/create_and_patch_python_wheel.sh
@@ -4,7 +4,7 @@
 set -e
 
 # set paths
-export LD_LIBRARY_PATH=$(pwd)/lib/sgpp:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=$(pwd)/lib:$LD_LIBRARY_PATH
 
 # create wheel and patch dependencies
 python3 setup.py bdist_wheel


### PR DESCRIPTION
This fixes #129 and makes life easier when using packaging software.