### PR TITLE
Replaced 1to8 avx instruction for non-MIC builds

### DIFF
--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming_multImpl.cpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming_multImpl.cpp
@@ -409,7 +409,11 @@ void OperationMultiEvalStreaming::multImpl(
         eval_11 = _mm512_castsi512_pd(_mm512_and_epi64(abs2Mask, _mm512_castpd_si512(eval_11)));
 #endif
 
+#if defined(__MIC__)
         __m512d one = _mm512_set_1to8_pd(1.0);
+#else
+        __m512d one = _mm512_set1_pd(1.0);
+#endif
 
         eval_0 = _mm512_sub_pd(one, eval_0);
         eval_1 = _mm512_sub_pd(one, eval_1);

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming_multImpl.cpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming_multImpl.cpp
@@ -295,6 +295,7 @@ void OperationMultiEvalStreaming::multImpl(
   _mm512_extload_pd(A, _MM_UPCONV_PD_NONE, _MM_BROADCAST_1X8, _MM_HINT_NONE)
 #define _mm512_max_pd(A, B) _mm512_gmax_pd(A, B)
 #define _mm512_set1_epi64(A) _mm512_set_1to8_epi64(A)
+#define _mm512_set1_pd(A) _mm512_set_1to8_pd(A)
 #endif
 #if defined(__AVX512F__)
 #define _mm512_broadcast_sd(A) _mm512_broadcastsd_pd(_mm_load_sd(A))
@@ -409,11 +410,7 @@ void OperationMultiEvalStreaming::multImpl(
         eval_11 = _mm512_castsi512_pd(_mm512_and_epi64(abs2Mask, _mm512_castpd_si512(eval_11)));
 #endif
 
-#if defined(__MIC__)
-        __m512d one = _mm512_set_1to8_pd(1.0);
-#else
         __m512d one = _mm512_set1_pd(1.0);
-#endif
 
         eval_0 = _mm512_sub_pd(one, eval_0);
         eval_1 = _mm512_sub_pd(one, eval_1);


### PR DESCRIPTION
There is a compilation error when building datadriven with ARCH=avx512 on a skylake CPU (tested with Xeon(R) Gold 6140 CPU).

```  >> 548    datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalStreaming/OperationMultiEvalStreaming_multImpl.cpp:412:23: 
            error: '_mm512_set_1to8_pd' was not declared in this scope
```

Fixing the compilation is simple enough: Switch from this instruction ```_mm512_set_1to8_pd``` to ```_mm512_set1_pd```. 
Unlike ```1to8``` this instruction actually also shows up in the [Intel Intrinsics Guide](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm512_set1_pd&expand=5236,4974).

I assume the 1to8 instruction is left over from the original KNC MIC implementation. This would also coincide with the git history of that file (and with the fact that is hard to come by any information about this instruction). For legacy/reproducibility purposes I have left it in there for builds with MICs and use set1 for all other builds! 