### PR TITLE
Preserve header blocks when using clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
-BasedOnStyle: Google
-ColumnLimit:  100
+BasedOnStyle:    Google
+ColumnLimit:     100
+IncludeBlocks:   Preserve


### PR DESCRIPTION
The default option of the google style is to regroup the headers with no
regards to any blocks. This is incompatible with our style checking
later in the build process!

This PR fixes this issue by setting the appropriate clang-format option.