### PR TITLE
Fix warnings that resulted from upgrading our test systems

### DIFF
--- a/base/src/sgpp/base/tools/json/Node.hpp
+++ b/base/src/sgpp/base/tools/json/Node.hpp
@@ -26,6 +26,8 @@ class Node {
 
   Node();
 
+  Node(const Node& right) = default;
+
   virtual ~Node() = default;
 
   virtual Node& operator=(const Node& right);

--- a/datadriven/src/sgpp/datadriven/application/LearnerBaseSP.cpp
+++ b/datadriven/src/sgpp/datadriven/application/LearnerBaseSP.cpp
@@ -66,11 +66,6 @@ LearnerBaseSP::LearnerBaseSP(const LearnerBaseSP& copyMe)
   this->GByte_ = 0.0;
   this->execTime_ = 0.0;
 
-  // safety, should not happen
-  if (alpha_ != nullptr) delete alpha_;
-
-  if (grid_ != nullptr) delete grid_;
-
   // can be solved better with a grid copy constructor
   grid_ = sgpp::base::Grid::unserialize(copyMe.grid_->serialize());
   alpha_ = new sgpp::base::DataVectorSP(*(copyMe.alpha_));

--- a/datadriven/src/sgpp/datadriven/application/RegressionLearner.cpp
+++ b/datadriven/src/sgpp/datadriven/application/RegressionLearner.cpp
@@ -189,7 +189,8 @@ void RegressionLearner::initializeGrid(const base::RegularGridConfiguration grid
 std::unique_ptr<datadriven::DMSystemMatrixBase> RegressionLearner::createDMSystem(
     base::DataMatrix& trainDataset) {
   using datadriven::RegularizationType;
-  base::OperationMatrix* opMatrix;
+  // initializing this is sadly neccesary to resolve a face-off between gcc and clang warnings
+  base::OperationMatrix* opMatrix = sgpp::op_factory::createOperationIdentity(*grid);
   switch (regularizationConfig.type_) {
     case RegularizationType::Identity:
       opMatrix = sgpp::op_factory::createOperationIdentity(*grid);
@@ -204,7 +205,6 @@ std::unique_ptr<datadriven::DMSystemMatrixBase> RegressionLearner::createDMSyste
     case RegularizationType::GroupLasso:
     case RegularizationType::Lasso:
     case RegularizationType::ElasticNet:
-    default:
       throw base::application_exception(
           "RegressionLearner::createDMSystem: An unsupported regularization type was chosen!");
   }

--- a/datadriven/src/sgpp/datadriven/application/RegressionLearner.cpp
+++ b/datadriven/src/sgpp/datadriven/application/RegressionLearner.cpp
@@ -204,6 +204,7 @@ std::unique_ptr<datadriven::DMSystemMatrixBase> RegressionLearner::createDMSyste
     case RegularizationType::GroupLasso:
     case RegularizationType::Lasso:
     case RegularizationType::ElasticNet:
+    default:
       throw base::application_exception(
           "RegressionLearner::createDMSystem: An unsupported regularization type was chosen!");
   }

--- a/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalMPI/OperationMultiEvalMPI.cpp
+++ b/datadriven/src/sgpp/datadriven/operation/hash/OperationMultiEvalMPI/OperationMultiEvalMPI.cpp
@@ -4,7 +4,6 @@
 // sgpp.sparsegrids.org
 
 #define MPICH_SKIP_MPICXX
-#define OMPI_SKIP_MPICXX
 #include <mpi.h>
 #include <omp.h>
 #include <algorithm>

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -560,7 +560,7 @@ def configureClangCompiler(config):
     "-Wno-documentation-unknown-command", "-Wno-exit-time-destructors", "-Wno-float-equal",
     "-Wno-global-constructors", "-Wno-missing-noreturn", "-Wno-missing-prototypes", "-Wno-padded",
     "-Wno-shadow", "-Wno-shadow-field", "-Wno-sign-conversion", "-Wno-undef",
-    "-Wno-unused-parameter", "-Wno-weak-vtables",
+    "-Wno-unused-parameter", "-Wno-weak-vtables", "-Wno-used-but-marked-unused",
   ]
   config.env.Append(CPPFLAGS=allWarnings)
 

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -409,6 +409,8 @@ def configureGNUCompiler(config):
     if "LINK" not in config.env.arguments: config.env["LINK"] = "mpicxx"
     if "CXX" not in config.env.arguments: config.env["CXX"] = "mpicxx"
     Helper.printInfo("Using openmpi.")
+    # openmpi specific fix according to: https://github.com/open-mpi/ompi/issues/5157
+    config.env["CPPDEFINES"]["OMPI_SKIP_MPICXX"] = "1"
   elif config.env["COMPILER"] == "mpich":
     if config.env["CC"]:
       config.env.Append(CFLAGS=["-cc=" + config.env["CC"]])


### PR DESCRIPTION
Compilation with an up-to-date clang (10+) currently triggers a lot of warnings when compiling boost tests. Since this is out of our reach to fix, the warnings are disabled for now.