### PR TITLE
Added lower-case install prefix flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -247,8 +247,11 @@ for moduleName in moduleNames:
 prefix=""
 if not env["PREFIX"]: # use scons default prefix UNLESS somebody added the sgpp PREFIX flag 
     prefix = env["prefix"]
+    print("Using prefix parameter to set the installation path: " + prefix)
 else:
     prefix = env["PREFIX"]
+    print("Warning, PREFIX parameter is overwriting the default prefix parameter!")
+    print("Using PREFIX parameter to set the installation path: " + prefix)
 env["EPREFIX"] = env.get("EPREFIX", prefix)
 env["LIBDIR"] = env.get("LIBDIR", os.path.join(env["EPREFIX"], "lib"))
 env["INCLUDEDIR"] = env.get("INCLUDEDIR", os.path.join(prefix, "include"))

--- a/SConstruct
+++ b/SConstruct
@@ -135,8 +135,10 @@ for moduleName in moduleNames:
   vars.Add(BoolVariable(moduleName, "Build the module " + moduleName +
                                     " (default: value of SG_ALL)", None))
 
-vars.Add("PREFIX", "Set prefix of the paths where " +
+vars.Add("prefix", "Set prefix of the paths where " +
                    "architecture-independent files are installed", "/usr/local")
+vars.Add("PREFIX", "Set prefix of the paths where " +
+                   "architecture-independent files are installed. Overwrites the lower-case argument prefix.", "")
 vars.Add("EPREFIX", "Set prefix of the path where " +
                     "architecture-dependent files are installed (default: PREFIX)")
 vars.Add("LIBDIR", "Set path where the built libraries are installed " +
@@ -242,9 +244,14 @@ env["SG_MATLAB"] = env.get("SG_MATLAB",
 for moduleName in moduleNames:
   env[moduleName] = env.get(moduleName, env["SG_ALL"])
 
-env["EPREFIX"] = env.get("EPREFIX", env["PREFIX"])
+prefix=""
+if not env["PREFIX"]: # use scons default prefix UNLESS somebody added the sgpp PREFIX flag 
+    prefix = env["prefix"]
+else:
+    prefix = env["PREFIX"]
+env["EPREFIX"] = env.get("EPREFIX", prefix)
 env["LIBDIR"] = env.get("LIBDIR", os.path.join(env["EPREFIX"], "lib"))
-env["INCLUDEDIR"] = env.get("INCLUDEDIR", os.path.join(env["PREFIX"], "include"))
+env["INCLUDEDIR"] = env.get("INCLUDEDIR", os.path.join(prefix, "include"))
 env["BOOST_LIBRARY_PATH"] = env.get("BOOST_LIBRARY_PATH", "/usr/lib/x86_64-linux-gnu"
                                     if env["PLATFORM"] not in ["darwin", "win32"]
                                     else "")


### PR DESCRIPTION
Some package managers (nix) expect scons projects to use the lower-case prefix parameter. This commit adds such a prefix parameter. To avoid breaking any existing scripts/installations/... the previous PREFIX parameter takes precedence over the lower-case prefix parameter. Unless you are dealing with a tool that expects a lower-case prefix, I would recommend to continue to use PREFIX. This PR just adds the alternative if required!