### PR TITLE
Fix github action tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: python -m pip install scons pywin32 numpy scipy matplotlib
       - uses: actions/checkout@v2
       - name: build
-        run: scons -j2 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" CPPFLAGS=-Werror
+        run: scons -j2 SG_PYTHON=0 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" CPPFLAGS=-Werror
       - name: on failed
         if: ${{ failure() }}
         run: type config.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         static: [0, 1]
@@ -32,14 +32,15 @@ jobs:
           Expand-Archive d:\a\_temp\swigwin-4.0.1.zip d:\a\_temp\;
       - name: setup-enviroment
         run: |
-         echo "c:\msys64\mingw64\bin" >> $GITHUB_PATH
+         echo "/mingw64/bin" >> $GITHUB_PATH
          echo "c:\hostedtoolcache\windows\Python\3.7.9\x64" >> $GITHUB_PATH
          echo "d:\a\_temp\swigwin-4.0.1" >> $GITHUB_PATH
+         echo "$PATH"
       - name: install python dependencies
         run: python -m pip install scons pywin32 numpy scipy matplotlib
       - uses: actions/checkout@v2
       - name: build
-        run: scons -j2 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" CC="C:\msys64\mingw64\bin\gcc.exe" CXX="C:\msys64\mingw64\bin\g++.exe" LINK="C:\msys64\mingw64\bin\g++.exe" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" CPPFLAGS=-Werror
+        run: scons -j2 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" CPPFLAGS=-Werror
       - name: on failed
         if: ${{ failure() }}
         run: type config.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: python -m pip install scons pywin32 numpy scipy matplotlib
       - uses: actions/checkout@v2
       - name: build
-        run: scons -j2 SG_PYTHON=0 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" CPPFLAGS=-Werror
+        run: scons -j2 SG_PYTHON=0 PYDOC=0 CHECK_STYLE=0 BUILD_STATICLIB=${{ matrix.static }} COMPILER=gnu OPT=1 GSL_INCLUDE_PATH="" CPPDEFINES="_POSIX_C_SOURCE=1" BOOST_INCLUDE_PATH="C:\msys64\mingw64\include" BOOST_LIBRARY_PATH="C:\msys64\mingw64\bin" 
       - name: on failed
         if: ${{ failure() }}
         run: type config.log

--- a/base/src/sgpp/base/operation/hash/OperationFirstMomentLinearBoundary.cpp
+++ b/base/src/sgpp/base/operation/hash/OperationFirstMomentLinearBoundary.cpp
@@ -7,6 +7,7 @@
 #include <sgpp/base/exception/application_exception.hpp>
 
 #include <sgpp/globaldef.hpp>
+#include <cstdint>
 
 namespace sgpp {
 namespace base {
@@ -34,8 +35,8 @@ double OperationFirstMomentLinearBoundary::doQuadrature(const DataVector& alpha,
     tmpres = 1.;
 
     for (size_t dim = 0; dim < storage.getDimension(); dim++) {
-      std::uint32_t index = iter->first->getIndex(dim);
-      std::uint32_t level = iter->first->getLevel(dim);
+      auto index = iter->first->getIndex(dim);
+      auto level = iter->first->getLevel(dim);
       double index_d = static_cast<double>(index);
       double level_d = static_cast<double>(level);
 

--- a/base/src/sgpp/base/operation/hash/OperationSecondMomentLinearBoundary.cpp
+++ b/base/src/sgpp/base/operation/hash/OperationSecondMomentLinearBoundary.cpp
@@ -7,6 +7,7 @@
 #include <sgpp/base/exception/application_exception.hpp>
 
 #include <sgpp/globaldef.hpp>
+#include <cstdint>
 
 namespace sgpp {
 namespace base {
@@ -34,8 +35,8 @@ double OperationSecondMomentLinearBoundary::doQuadrature(DataVector& alpha, Data
     tmpres = 1.;
 
     for (size_t dim = 0; dim < storage.getDimension(); dim++) {
-      std::uint32_t index = iter->first->getIndex(dim);
-      std::uint32_t level = iter->first->getLevel(dim);
+      auto index = iter->first->getIndex(dim);
+      auto level = iter->first->getLevel(dim);
       double index_d = static_cast<double>(index);
       double level_d = static_cast<double>(level);
 

--- a/base/src/sgpp/base/tools/json/Node.hpp
+++ b/base/src/sgpp/base/tools/json/Node.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <cstdint>
 
 namespace json {
 

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOnlineDEOrthoAdapt.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOnlineDEOrthoAdapt.cpp
@@ -96,13 +96,10 @@ void DBMatOnlineDEOrthoAdapt::solveSLE(
       static_cast<sgpp::datadriven::DBMatOfflineOrthoAdapt*>(
           &this->offlineObject);
   // create solver
-  sgpp::datadriven::DBMatDMSOrthoAdapt* solver =
-      new sgpp::datadriven::DBMatDMSOrthoAdapt();
+  auto solver = std::make_unique<sgpp::datadriven::DBMatDMSOrthoAdapt>();
   // solve the created system
   alpha.resizeZero(b.getSize());
   solver->solve(offline->getTinv(), offline->getQ(), this->getB(), b, alpha);
-
-  free(solver);
 }
 
 void DBMatOnlineDEOrthoAdapt::solveSLEParallel(

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatOnlineDE_SMW.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatOnlineDE_SMW.cpp
@@ -158,12 +158,10 @@ void DBMatOnlineDE_SMW::solveSLE(
     DataVector& alpha, DataVector& b, Grid& grid,
     DensityEstimationConfiguration& densityEstimationConfig, bool do_cv) {
   // create solver
-  sgpp::datadriven::DBMatDMS_SMW* solver = new sgpp::datadriven::DBMatDMS_SMW();
+  auto solver = std::make_unique<sgpp::datadriven::DBMatDMS_SMW>();;
   // solve the created system
   alpha.resizeZero(b.getSize());
   solver->solve(this->offlineObject.getInverseMatrix(), this->getB(), b, alpha);
-
-  free(solver);
 }
 
 void DBMatOnlineDE_SMW::solveSLEParallel(
@@ -171,6 +169,7 @@ void DBMatOnlineDE_SMW::solveSLEParallel(
     DensityEstimationConfiguration& densityEstimationConfig, bool do_cv) {
 #ifdef USE_SCALAPACK
   // create solver
+  auto solver = std::make_unique<sgpp::datadriven::DBMatDMS_SMW>();
   sgpp::datadriven::DBMatDMS_SMW* solver = new sgpp::datadriven::DBMatDMS_SMW();
   // solve the created system
   alpha.resize(b.getGlobalRows());

--- a/datadriven/src/sgpp/datadriven/algorithm/GridFactory.hpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/GridFactory.hpp
@@ -8,6 +8,7 @@
 #include <sgpp/base/grid/Grid.hpp>
 #include <sgpp/datadriven/configuration/GeometryConfiguration.hpp>
 
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>

--- a/datadriven/src/sgpp/datadriven/datamining/modules/dataSource/DataSourceConfig.hpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/dataSource/DataSourceConfig.hpp
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace sgpp {
 namespace datadriven {

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -3,7 +3,8 @@
 # use, please see the copyright notice provided with SG++ or at
 # sgpp.sparsegrids.org
 
-
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning) 
 import distutils.sysconfig
 import errno
 import os
@@ -311,6 +312,8 @@ def checkPython(config):
         raise Exception("Python 3 is required for SGpp python support!")
       
     pythonpath = getOutput(["python3", "-c",
+          "import warnings; "
+          "warnings.filterwarnings(\"ignore\", category=DeprecationWarning); " 
           "import distutils.sysconfig; "
           "print(distutils.sysconfig.get_python_inc())"])
     package = "python3-dev"

--- a/tools/ci_scripts/install_pip_packaging_tools.sh
+++ b/tools/ci_scripts/install_pip_packaging_tools.sh
@@ -9,7 +9,7 @@ sudo -H pip3 install setuptools wheel scipy numpy jinja2
 # install patchelf
 git clone https://github.com/NixOS/patchelf.git
 pushd patchelf
-git checkout tags/0.10
+git checkout tags/0.14.5
 ./bootstrap.sh
 ./configure
 make


### PR DESCRIPTION
The python check fails due to a deprecation warning (distutils).

It seems the recommended way forward is to use sysconfig instead. That should be mostly straightforward as only SGppConfigure.py is affected. However, apparently moving from distutils to sysconfig can be a bit quirky on some platforms ([for example here](https://bugs.launchpad.net/ubuntu/+source/python3.10/+bug/1940705)). Not quite sure how relevant those issues still are since it has been a while since I looked into it.

Until we can get around to use sysconfig (and more importantly, test it on all platforms we care about), this PR provides a quick workaround for the build issues with python 3.10 and 3.11 by simply disabling the deprecation warning. However, this will of course only work up until python 3.12 as distutils will be gone then.

See issue #263 