### PR TITLE
Remove distutils and switch to sysconfig

### DIFF
--- a/pysgpp/SConscript
+++ b/pysgpp/SConscript
@@ -76,8 +76,8 @@ if env["USE_ZLIB"]:
 
 if (env["PLATFORM"] == "win32") and (env["COMPILER"] == "gnu"):
   pyEnv.AppendUnique(CPPDEFINES=["MS_WIN64"])
-  pythonVersion = getOutput(["python3", "-c", "import distutils.sysconfig; "
-                             "print(distutils.sysconfig.get_config_var(\"VERSION\"))"])
+  pythonVersion = getOutput(["python3", "-c", "import sysconfig; "
+                             "print(sysconfig.get_config_var(\"VERSION\"))"])
   libs.append("python{}".format(pythonVersion))
   # GCC sometimes fails with internal compiler error on mingw-w64
   # (e.g., "in gt_ggc_m_S, at ggc-page.c:1474" or "segmentation fault").

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -3,9 +3,7 @@
 # use, please see the copyright notice provided with SG++ or at
 # sgpp.sparsegrids.org
 
-import warnings
-warnings.filterwarnings("ignore", category=DeprecationWarning) 
-import distutils.sysconfig
+import sysconfig
 import errno
 import os
 import re
@@ -312,10 +310,8 @@ def checkPython(config):
         raise Exception("Python 3 is required for SGpp python support!")
       
     pythonpath = getOutput(["python3", "-c",
-          "import warnings; "
-          "warnings.filterwarnings(\"ignore\", category=DeprecationWarning); " 
-          "import distutils.sysconfig; "
-          "print(distutils.sysconfig.get_python_inc())"])
+          "import sysconfig; "
+          "print(sysconfig.get_path(\"include\"))"])
     package = "python3-dev"
 
     config.env.AppendUnique(CPPPATH=[pythonpath])


### PR DESCRIPTION
This PR removes the (deprecated) distutils altogether and simply replaces it with the appropriate sysconfig calls.

Fixes #263 