### PR TITLE
Add GitHub Pages Documentation CI 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,35 @@
+name: generate documentation
+
+# triggers
+on:
+  push:
+    branches:
+      - master
+      - add_github_pages_doc
+
+jobs:
+  build-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      # checkout repository
+      - name: Checkout sgpp
+        uses: actions/checkout@v4
+        with:
+          path: sgpp
+      # install dependencies
+      - name: Dependancies
+        run: |
+          python -m pip install scons
+          sudo apt update
+          sudo apt-get install -y libboost-test-dev swig doxygen graphviz
+      # SCons
+      - name: SCons
+        run: |
+          cd sgpp
+          scons SG_ALL=1 SG_PYTHON=1 PYDOC=1 doxygen
+      # deploy to github pages
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./sgpp/doc/html

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: sgpp
       # install dependencies
-      - name: Dependancies
+      - name: Dependencies
         run: |
           python -m pip install scons
           sudo apt update

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - add_github_pages_doc
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - add_github_pages_doc
 
 jobs:
   build-documentation:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+    workflow_dispatch:
 
 jobs:
   build-documentation:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-    workflow_dispatch:
+  workflow_dispatch:
 
 jobs:
   build-documentation:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - add_github_pages_doc
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ You are invited to use, contribute, discuss, …
 The library is free to use, provided proper credit is given.
 
 For more details, the API documentation, usage examples and tutorials, please visit:
+
 https://sgpp.github.io/SGpp/
 
 More information can also be found at:
+
 http://sgpp.sparsegrids.org
 
 You can find binaries for Linux (deb) and MATLAB support in the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ You are invited to use, contribute, discuss, …
 
 The library is free to use, provided proper credit is given.
 
-For more details and the API documentation, please visit http://sgpp.sparsegrids.org.
+For more details, the API documentation, usage examples and tutorials, please visit https://sgpp.github.io/SGpp/
+More information can also be found at http://sgpp.sparsegrids.org.
 
 You can find binaries for Linux (deb) and MATLAB support in the
 [SG++ releases](https://github.com/SGpp/SGpp/releases).

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ You are invited to use, contribute, discuss, …
 
 The library is free to use, provided proper credit is given.
 
-For more details, the API documentation, usage examples and tutorials, please visit https://sgpp.github.io/SGpp/
-More information can also be found at http://sgpp.sparsegrids.org.
+For more details, the API documentation, usage examples and tutorials, please visit:
+https://sgpp.github.io/SGpp/
+
+More information can also be found at:
+http://sgpp.sparsegrids.org
 
 You can find binaries for Linux (deb) and MATLAB support in the
 [SG++ releases](https://github.com/SGpp/SGpp/releases).


### PR DESCRIPTION
### Problem this PR addresses:
Currently, our documentation is residing at three different locations:
- We have the Doxygen documentation directly in our repository. This is our most up-to-date documentation. However, it requires our users  to build it themselves using a local copy and Doxygen.
- We do have an online version for our Doxygen documentation at https://sgpp.sparsegrids.org/docs/, but it is horribly out of date (2019) and currently features not automatic updates.
- We have some documentation in our Wiki (https://github.com/SGpp/SGpp/wiki). This documentation includes usage examples (copied from our doxygen), as well as build instruction that can only be found in the Wiki so far (so it is not entirely duplicated). Worse, the math symbols got messed up in the tutorials (see for example https://github.com/SGpp/SGpp/wiki/Base-quick-start-(Python) ).

This is hardly ideal and, in the case of missing math symbols and the out-of-date documentation, rather confusing.

### Solution:
I think it is best if we unify these three locations using GitHub pages and our existing Doxygen setup within the code.
This PR adds a new CI pipeline that builds the current Doxygen documentation and pushes it to https://sgpp.github.io/SGpp/ for every commit to master.  This way, the documentation is always up-to-date (and the math symbols are displayed correctly).

### Next Steps:
I think the next steps should be to move the extra build information from the Wiki to the Doxygen documentation so we have everything in one place. This is also a good opportunity to add build instructions for using our Spack package. I also think we should remove the obsolete documentation from  https://sgpp.sparsegrids.org and rather use this site for sgpp-related news, blog posts and publications (not for the code/build documentation).