### PR TITLE
Fix tests with additional dependencies

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -443,6 +443,10 @@ if env["RUN_PYTHON_TESTS"]:
     Helper.printWarning("Python tests disabled because SG_PYTHON is disabled.")
 
 if env["COMPILE_BOOST_TESTS"]:
+  # also add the Boost library path to the PATH
+  # so that the Boost test lib can be found when running the tests
+  env["ENV"]["LD_LIBRARY_PATH"] = os.pathsep.join([env["BOOST_LIBRARY_PATH"],
+                                        env["ENV"].get("LD_LIBRARY_PATH", "")])
   builder = Builder(action="./$SOURCE --log_level=test_suite")
   env.Append(BUILDERS={"BoostTest" : builder})
 

--- a/combigrid/examples/combigrid.py
+++ b/combigrid/examples/combigrid.py
@@ -41,7 +41,7 @@ def plotFunction(opEval, surpluses, X):
 
   # actual plotting
   fig = plt.figure(figsize=(6, 6))
-  ax = fig.gca(projection="3d")
+  ax = fig.add_subplot(projection="3d")
   ax.plot_surface(XX0, XX1, YY)
   ax.plot(X[:,0], X[:,1], "k.", zs=f(X[:,0], X[:,1]), ms=10)
 

--- a/combigrid/examples/combigrid_adaptive.py
+++ b/combigrid/examples/combigrid_adaptive.py
@@ -44,7 +44,7 @@ def plotFunction(opEval, surpluses, X):
 
     # actual plotting
     fig = plt.figure(figsize=(6, 6))
-    ax = fig.gca(projection="3d")
+    ax = fig.add_subplot(projection="3d")
     ax.plot_surface(XX0, XX1, YY)
     ax.plot(X[:, 0], X[:, 1], "k.", zs=f(X[:, 0], X[:, 1]), ms=10)
 

--- a/combigrid/python/plotDeltas3d.py
+++ b/combigrid/python/plotDeltas3d.py
@@ -87,7 +87,8 @@ try:
             lInfo = {"l_" + str(j): (levels[i][j])
                      for j in range(len(levels[i]))}
             lInfo["delta"] = float(deltas[i])
-            df = df.append(lInfo, ignore_index=True)
+            df_dictionary = pd.DataFrame([lInfo])
+            df = pd.concat([df, df_dictionary], ignore_index=True)
         # drop potential nan values
         df = df.dropna()
         return df
@@ -134,7 +135,7 @@ try:
             axes.set_zlim(0.6, 1+max(range_zero, range_one))
         axes.add_collection3d(collection)
 
-        cbar = canvas.colorbar(scalarMap)
+        cbar = canvas.colorbar(scalarMap, ax=plt.gca())
 
         show()
 

--- a/datadriven/SConscript
+++ b/datadriven/SConscript
@@ -83,7 +83,11 @@ if env["USE_HPX"]:
 module.runPythonTests()
 module.buildBoostTests()
 module.runBoostTests()
+# Build performance tests...
 module.buildBoostTests("performanceTests", compileFlag=performanceTestFlag)
-module.runBoostTests("performanceTests", compileFlag=performanceTestFlag,
-                     runFlag=performanceTestRunFlag)
+# ... however, without OCL they are empty (via ifdefs) and boost would does
+# throw an error. Only run them when OCL is used
+if env["USE_OCL"]: 
+    module.runBoostTests("performanceTests", compileFlag=performanceTestFlag,
+                         runFlag=performanceTestRunFlag)
 module.checkStyle()

--- a/datadriven/python/uq/plot/plot3d.py
+++ b/datadriven/python/uq/plot/plot3d.py
@@ -18,7 +18,7 @@ from pysgpp.extensions.datadriven.uq.plot.colors import load_default_color_map
 
 def plotDensity3d(U, n=36):
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     xlim = U.getBounds()[0]
     ylim = U.getBounds()[1]
     x = np.linspace(xlim[0], xlim[1], n + 1, endpoint=True)
@@ -50,7 +50,7 @@ def plotDensity3d(U, n=36):
 def plotGrid3d(grid, grid_points_at=0, ax=None):
     if ax is None:
         fig = plt.figure()
-        ax = fig.gca(projection='3d')
+        ax = fig.add_subplot(projection='3d')
     # get grid points
     gs = grid.getStorage()
     gps = np.zeros([gs.getSize(), 2])
@@ -83,7 +83,7 @@ def plotSG3d(grid, alpha, n=36,
              surface_plot=False,
              xoffset=0.0, yoffset=1.0):
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     x = np.linspace(0, 1, n + 1, endpoint=True)
     y = np.linspace(0, 1, n + 1, endpoint=True)
     Z = np.zeros((n + 1, n + 1))
@@ -138,7 +138,7 @@ def plotSG3d(grid, alpha, n=36,
 def plotFunction3d(f, xlim=[0, 1], ylim=[0, 1], n=36,
                    z_min=np.Inf, xoffset=0.0, yoffset=1.0):
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     x = np.linspace(xlim[0], xlim[1], n + 1, endpoint=True)
     y = np.linspace(ylim[0], ylim[1], n + 1, endpoint=True)
     xv, yv = np.meshgrid(x, y, sparse=False, indexing='xy')
@@ -199,7 +199,7 @@ def plotKDE3d(values):
 
 def plotError3d(f1, f2, xlim=[0, 1], ylim=[0, 1], n=32):
     fig = plt.figure()
-    ax = fig.gca(projection='3d')
+    ax = fig.add_subplot(projection='3d')
     x = np.linspace(xlim[0], xlim[1], n + 1, endpoint=True)
     y = np.linspace(ylim[0], ylim[1], n + 1, endpoint=True)
     Z = np.zeros((n + 1, n + 1))

--- a/tools/check_copyright_banners.py
+++ b/tools/check_copyright_banners.py
@@ -69,9 +69,9 @@ def processFilePy(path):
     return True
 
   if not (re.match(COPYRIGHT_BANNER, source) or
-          re.match("#!.*?\s*"+COPYRIGHT_BANNER, source) or
-          re.match("# -\*- coding: utf-8 -\*-\s*"+COPYRIGHT_BANNER, source) or
-          re.match("#!.*?\n# -\*- coding: utf-8 -\*-\s*"+COPYRIGHT_BANNER, source)):
+          re.match(r'#!.*?\s*'+COPYRIGHT_BANNER, source) or
+          re.match(r'# -\*- coding: utf-8 -\*-\s*'+COPYRIGHT_BANNER, source) or
+          re.match(r'#!.*?\n# -\*- coding: utf-8 -\*-\s*'+COPYRIGHT_BANNER, source)):
     print(("{}:0: warning: No SG++ copyright message found or existing "
            "copyright message is not the standard SG++ copyright "
            "message.  [legal/copyright] [5]"

--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -170,7 +170,7 @@ Syntax: cpplint.py [--verbose=#] [--output=vs7] [--filter=-x,+y,...]
 
       Example file:
         filter=-build/include_order,+build/include_alpha
-        exclude_files=.*\.cc
+        exclude_files=.*\\.cc
 
     The above example disables build/include_order warning and enables
     build/include_alpha as well as excludes all .cc from being
@@ -971,7 +971,7 @@ class FileInfo(object):
     If we have a real absolute path name here we can try to do something smart:
     detecting the root of the checkout and truncating /path/to/checkout from
     the name so that we get header guards that don't include things like
-    "C:\Documents and Settings\..." or "/home/username/..." in them and thus
+    "C:\\Documents and Settings\\..." or "/home/username/..." in them and thus
     people on different computers who have checked the source out to different
     locations won't see bogus errors.
     """


### PR DESCRIPTION
I've been expanding our CI tests and spack package over the last few days and encountered some more bugs and deprecation issues whilst doing so. These are addressed in this PR (in a sense, the PR is a continuation of #271, covering issues which were not encountered by our normal tests):

- Fixes deprecated matplotlib calls
- Fixes deprecated pandas calls
- Fixes datadriven boost performance tests when OpenCL is turned off
- Fixes more Python string issues
- Properly allows using a boost installation within a custom directory (previously one could pass the paths to scons but the boost tests would not run this way unless boost was found in the standard system directory).

I will keep this as a draft PR for now as I suspect there are some more issues lurking in the code which will show themselves as I continue with the tests and spack improvements.