### PR TITLE
Add experimental aarch64 support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -106,7 +106,7 @@ vars.Add("LIBPATH", "Set path where to look for additional libraries", "",
                     converter=Helper.multiParamPathConverter)
 vars.Add("ARCH", "Set the architecture, the possible values are compiler-dependent, " +
                  "for COMPILER=gnu, e.g., the following values are possible: " +
-                 "sse3, sse42, avx, fma4, avx2, avx512", "sse3")
+                 "sse3, sse42, avx, fma4, avx2, avx512, aarch64", "sse3")
 vars.Add("COMPILER", "Set the compiler, \"gnu\" means using gcc with standard configuration, " +
                      "the following values are possible: " +
                      "gnu, clang, intel, openmpi, mpich, intel.mpi; " +

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatDatabase.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatDatabase.cpp
@@ -141,7 +141,7 @@ void DBMatDatabase::putDataMatrix(
     if (gridConfig.generalType_ == sgpp::base::GeneralGridType::ComponentGrid) {
       json::ListNode& level =
           dynamic_cast<json::ListNode&>(gridConfigEntry.addListAttr(keyGridLevel));
-      for (size_t i = 0; i < gridConfig.levelVector_.size(); i++) {
+      for (uint64_t i = 0; i < gridConfig.levelVector_.size(); i++) {
         level.addIdValue(gridConfig.levelVector_[i]);
       }
     } else {

--- a/pde/src/sgpp/pde/algorithm/UpDownFourOpDims.cpp
+++ b/pde/src/sgpp/pde/algorithm/UpDownFourOpDims.cpp
@@ -133,7 +133,7 @@ void UpDownFourOpDims::specialOpX(
     sgpp::base::DataVector result_temp(alpha.getSize());
     sgpp::base::DataVector temp_two(alpha.getSize());
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp, result)
+#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp, result, pt2UpFunc)
     {
       (this->*pt2UpFunc)(alpha, temp, this->algoDims[dim]);
       updown(temp, result, dim - 1, op_dim_one, op_dim_two, op_dim_three, op_dim_four);
@@ -141,7 +141,7 @@ void UpDownFourOpDims::specialOpX(
 
 // Same from the other direction:
 #pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp_two, \
-                                                                        result_temp)
+                                                                        result_temp, pt2DownFunc)
     {  // NOLINT(whitespace/braces)
       updown(alpha, temp_two, dim - 1, op_dim_one, op_dim_two, op_dim_three, op_dim_four);
       (this->*pt2DownFunc)(temp_two, result_temp, this->algoDims[dim]);
@@ -154,10 +154,10 @@ void UpDownFourOpDims::specialOpX(
     // Terminates dimension recursion
     sgpp::base::DataVector temp(alpha.getSize());
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, result)
+#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, result, pt2UpFunc)
     (this->*pt2UpFunc)(alpha, result, this->algoDims[dim]);
 
-#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp)
+#pragma omp task if (curNumAlgoDims - dim <= curMaxParallelDims) shared(alpha, temp, pt2DownFunc)
     (this->*pt2DownFunc)(alpha, temp, this->algoDims[dim]);
 
 #pragma omp taskwait

--- a/site_scons/SGppConfigure.py
+++ b/site_scons/SGppConfigure.py
@@ -455,7 +455,7 @@ def configureGNUCompiler(config):
   #     ensure you also compile with -fno-strict-aliasing"
   config.env.Append(CPPFLAGS=allWarnings + [
       "-fno-strict-aliasing",
-      "-funroll-loops", "-mfpmath=sse"])
+      "-funroll-loops"])
 
   # Mitigation for old Ubuntu (should probably be also applied to Debian?):
   # Package 'libomp-dev' installs a symlink 'libgomp.so' to 'libomp.so' in /usr/lib/x86_64-linux.
@@ -507,23 +507,31 @@ def configureGNUCompiler(config):
 
   if config.env["ARCH"] == "sse3":
     config.env.AppendUnique(CPPFLAGS=["-msse3"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
   elif config.env["ARCH"] == "sse42":
     config.env.AppendUnique(CPPFLAGS=["-msse4.2"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
   elif config.env["ARCH"] == "avx":
     config.env.AppendUnique(CPPFLAGS=["-mavx"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
   elif config.env["ARCH"] == "fma4":
     config.env.AppendUnique(CPPFLAGS=["-mavx"])
     config.env.AppendUnique(CPPFLAGS=["-mfma4"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
   elif config.env["ARCH"] == "avx2":
     config.env.AppendUnique(CPPFLAGS=["-mavx2"])
     config.env.AppendUnique(CPPFLAGS=["-mfma"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
   elif config.env["ARCH"] == "avx512":
     config.env.AppendUnique(CPPFLAGS=["-mavx512f"])
     config.env.AppendUnique(CPPFLAGS=["-mavx512cd"])
     config.env.AppendUnique(CPPFLAGS=["-mfma"])
+    config.env.AppendUnique(CPPFLAGS=["-mfpmath=sse"])
+  elif config.env["ARCH"] == "aarch64":
+    config.env.AppendUnique(CPPFLAGS=[""])
   else:
     Helper.printErrorAndExit("You must specify a valid ARCH value for gnu.",
-                             "Available configurations are: sse3, sse42, avx, fma4, avx2, avx512")
+                             "Available configurations are: sse3, sse42, avx, fma4, avx2, avx512, aarch64")
 
   # check if using MinGW (g++ on win32)
   if config.env["PLATFORM"] == "win32":
@@ -589,9 +597,11 @@ def configureClangCompiler(config):
     config.env.AppendUnique(CPPFLAGS=["-mavx512f"])
     config.env.AppendUnique(CPPFLAGS=["-mavx512cd"])
     config.env.AppendUnique(CPPFLAGS=["-mfma"])
+  elif config.env["ARCH"] == "aarch64":
+    config.env.AppendUnique(CPPFLAGS=[""])
   else:
     Helper.printErrorAndExit("You must specify a valid ARCH value for clang.",
-                             "Available configurations are: sse3, sse4.2, avx, fma4, avx2, avx512")
+                             "Available configurations are: sse3, sse4.2, avx, fma4, avx2, avx512, aarch64")
 
 def configureIntelCompiler(config):
   config.env.AppendUnique(CPPFLAGS=["-Wall", "-ansi", "-Wno-deprecated", "-wd1125",
@@ -642,9 +652,11 @@ def configureIntelCompiler(config):
     config.env.AppendUnique(CPPFLAGS=["-mmic"])
     config.env.AppendUnique(LINKFLAGS=["-mmic"])
     config.env["CPPDEFINES"]["USEMIC"] = "1"
+  elif config.env["ARCH"] == "aarch64":
+    config.env.AppendUnique(CPPFLAGS=[""])
   else:
     Helper.printErrorAndExit("You must specify a valid ARCH value for intel.",
-                             "Available configurations are: sse3, sse4.2, avx, avx2, avx512, mic")
+                             "Available configurations are: sse3, sse4.2, avx, avx2, avx512, mic, aarch64")
 
 def detectGSL(config):
   if "GSL_INCLUDE_PATH" in config.env:


### PR DESCRIPTION
This PR adds experimental support for aarch64.

It thus contains: Changes to the build system (allowing passing aarch64 arch values) and some bugfixes for issues I encountered when compiling SGpp on an arm system (fixing a llvm crash in datadriven). 

The PR also aims to address the compilation issues on current apple mac machines (see #275 ).