### PR TITLE
Support for Apple Silicon M*-Chips

### DIFF
--- a/base/examples/benchmark_gridInteraction.cpp
+++ b/base/examples/benchmark_gridInteraction.cpp
@@ -8,7 +8,7 @@
 #include <sgpp/base/grid/Grid.hpp>
 #include <sgpp/base/operation/BaseOpFactory.hpp>
 
-#include <bits/stdc++.h>
+// #include <bits/stdc++.h>
 #include <chrono>
 #include <set>
 #include <vector>

--- a/datadriven/src/sgpp/datadriven/algorithm/DBMatDatabase.cpp
+++ b/datadriven/src/sgpp/datadriven/algorithm/DBMatDatabase.cpp
@@ -142,7 +142,7 @@ void DBMatDatabase::putDataMatrix(
       json::ListNode& level =
           dynamic_cast<json::ListNode&>(gridConfigEntry.addListAttr(keyGridLevel));
       for (uint64_t i = 0; i < gridConfig.levelVector_.size(); i++) {
-        level.addIdValue(gridConfig.levelVector_[i]);
+        level.addIdValue(static_cast<uint64_t>(gridConfig.levelVector_[i]));
       }
     } else {
       gridConfigEntry.addIDAttr(keyGridLevel, static_cast<int64_t>(gridConfig.level_));

--- a/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerClassification.cpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerClassification.cpp
@@ -564,7 +564,7 @@ void VisualizerClassification::storeHeatmapJsonClassification(DataMatrix &matrix
       jsonOutput["data"][graphIndex]["marker"].
       addIDAttr("symbol", "\"star-dot\"");
       jsonOutput["data"][graphIndex]["marker"].
-      addIDAttr("size", static_cast<size_t>(10));
+      addIDAttr("size", static_cast<uint64_t>(10));
       jsonOutput["data"][graphIndex]["marker"].
       addDictAttr("line");
       jsonOutput["data"][graphIndex]["marker"]["line"].
@@ -846,7 +846,7 @@ void VisualizerClassification::storeHeatmapJsonClassification(DataMatrix &matrix
     jsonOutput["data"][graphIndex].addDictAttr("marker");
     jsonOutput["data"][graphIndex]["marker"].addIDAttr("symbol", "\"star-dot\"");
     jsonOutput["data"][graphIndex]["marker"].addIDAttr("size",
-      static_cast<size_t>(10));
+      static_cast<u_int64_t>(10));
     jsonOutput["data"][graphIndex]["marker"].addDictAttr("line");
     jsonOutput["data"][graphIndex]["marker"]["line"].addIDAttr("color", "\"blue\"");
     jsonOutput["data"][graphIndex]["marker"]["line"].addIDAttr("width", 1.5);

--- a/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerClassification.cpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerClassification.cpp
@@ -846,7 +846,7 @@ void VisualizerClassification::storeHeatmapJsonClassification(DataMatrix &matrix
     jsonOutput["data"][graphIndex].addDictAttr("marker");
     jsonOutput["data"][graphIndex]["marker"].addIDAttr("symbol", "\"star-dot\"");
     jsonOutput["data"][graphIndex]["marker"].addIDAttr("size",
-      static_cast<u_int64_t>(10));
+      static_cast<uint64_t>(10));
     jsonOutput["data"][graphIndex]["marker"].addDictAttr("line");
     jsonOutput["data"][graphIndex]["marker"]["line"].addIDAttr("color", "\"blue\"");
     jsonOutput["data"][graphIndex]["marker"]["line"].addIDAttr("width", 1.5);

--- a/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerDensityEstimation.cpp
+++ b/datadriven/src/sgpp/datadriven/datamining/modules/visualization/VisualizerDensityEstimation.cpp
@@ -1004,7 +1004,7 @@ std::vector<size_t> indexes, size_t &varDim1, size_t &varDim2, std::string filep
     tempGrid.getColumn(varDim2, yColGrid);
 
     jsonOutput["data"][graphIndex].addIDAttr("y", yColGrid.toString());
-    jsonOutput["data"][graphIndex].addIDAttr("legendgroup", static_cast<size_t>(1));
+    jsonOutput["data"][graphIndex].addIDAttr("legendgroup", static_cast<uint64_t>(1));
     jsonOutput["data"][graphIndex].addIDAttr("hoverinfo", "\"x+y\"");
 
     if (showLegendGroup && tempGrid.getNrows() > 0) {


### PR DESCRIPTION
Related to #275
Fixes compilation for SGpp on MacOS using homebrew dependencies.

This command should work:
`/opt/homebrew/bin/scons -j 10 ARCH=aarch64 CC=/opt/homebrew/Cellar/llvm/20.1.3/bin/clang-20 CXX=/opt/homebrew/Cellar/llvm/20.1.3/bin/clang++ BOOST_LIBRARY_PATH=/opt/homebrew/Cellar/boost/1.88.0/lib/ BOOST_INCLUDE_PATH=/opt/homebrew/Cellar/boost/1.88.0/include/ PREFIX=$HOME/sgpp-install RUN_BOOST_TESTS=OFF`